### PR TITLE
Process dataframe docstrings

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python=3.8
+- biopython
 - black
 - conda
 - flake8
@@ -11,6 +12,7 @@ dependencies:
 - matplotlib
 - mypy
 - nbstripout
+- networkx
 - numpy
 - pandas
 - pip
@@ -20,4 +22,5 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
+- rdkit
 - scipy


### PR DESCRIPTION
@a-r-j requesting a short review on this one.

I added docstrings to the `process_dataframe` function, and slightly modified its implementation for simplicity. 

One thing I'm a bit unsure of: `if granularity == something` shows up in two places. Do you think this can be simplified? "granularity" as a category of properties to worry about -- if it can be handled in one block of code rather than two, that would help with reasoning about the function and debugging/maintenance later on.