### PR TITLE
[RNA Graphs] Added initial RNA graph API

### DIFF
--- a/graphein/construct_graphs.py
+++ b/graphein/construct_graphs.py
@@ -1419,13 +1419,13 @@ class ProteinGraph(object):
     """"
     @staticmethod
     def get_voronoi_edges(protein_df, furthest_site=False, incremental=False):
-        
+
         #Calculate Voronoi edges from protein dataframe
         #:param protein_df:
         #:param furthest_site:
         ##:param incremental:
         #:return:
-        
+
         coord = protein_df[['x_coord', 'y_coord', 'z_coord']]
         vor = spatial.Voronoi(points=coord, furthest_site=furthest_site, incremental=incremental)
         edges = pd.DataFrame(vor.ridge_points)

--- a/graphein/construct_meshes.py
+++ b/graphein/construct_meshes.py
@@ -77,7 +77,6 @@ class ProteinMesh(object):
         return verts, faces, aux
 
 
-
 if __name__ == "__main__":
     p = ProteinMesh()
     print(p.create_mesh(pdb_code="3eiy", out_dir="../examples/meshes/"))

--- a/graphein/construct_meshes.py
+++ b/graphein/construct_meshes.py
@@ -8,6 +8,7 @@
 
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
+from ipymol import viewer as pymol
 from pytorch3d.io import load_obj, save_obj
 
 
@@ -76,7 +77,6 @@ class ProteinMesh(object):
         return verts, faces, aux
 
 
-from ipymol import viewer as pymol
 
 if __name__ == "__main__":
     p = ProteinMesh()

--- a/graphein/diffusion.py
+++ b/graphein/diffusion.py
@@ -11,6 +11,9 @@ import xarray as xr
 
 from .features.edges.distance import compute_distmat
 from .utils import format_adjacency, generate_feature_dataframe
+import numpy as np
+from typing import Dict
+import pandas as pd
 
 
 def identity_matrix(G: nx.Graph) -> xr.DataArray:
@@ -71,8 +74,7 @@ def inverse_distance_matrix(G, power) -> xr.DataArray:
         coords = pd.Series(
             {coord_name: d[coord_name] for coord_name in coord_names}, name=n
         )
-
-    return coords
+        return coords
 
     coords = generate_feature_dataframe(G, funcs=[extract_coords])
     distmat = compute_distmat(coords).values
@@ -80,7 +82,7 @@ def inverse_distance_matrix(G, power) -> xr.DataArray:
     I = np.eye(len(G))
     distmat = (distmat + I) ** power
     distmat = 1 / distmat
-    distamt -= I
+    distmat -= I
     return format_adjacency(
         G, distmat, f"inverse_distance_matrix_power_{power}"
     )

--- a/graphein/diffusion.py
+++ b/graphein/diffusion.py
@@ -9,8 +9,8 @@ These arrays can then be stacked to generate a diffusion tensor.
 import networkx as nx
 import xarray as xr
 
-from .utils import format_adjacency, generate_feature_dataframe
 from .features.edges.distance import compute_distmat
+from .utils import format_adjacency, generate_feature_dataframe
 
 
 def identity_matrix(G: nx.Graph) -> xr.DataArray:

--- a/graphein/diffusion.py
+++ b/graphein/diffusion.py
@@ -25,7 +25,7 @@ def identity_matrix(G: nx.Graph) -> xr.DataArray:
 def adjacency_matrix_power(
     G: nx.Graph,
     amat_kwargs: Dict = {},
-    with_identity: bool = True
+    with_identity: bool = True,
     power: float = 1,
 ) -> xr.DataArray:
     """Return the matrix power of the adjacency matrix.
@@ -65,11 +65,13 @@ def inverse_distance_matrix(G, power) -> xr.DataArray:
     :param G: NetworkX Graph object.
     :param power: The power for the distance calculation.
     """
+
     def extract_coords(n, d):
         coord_names = ("x_coord", "y_coord", "z_coord")
-        coords = pd.Series({
-            coord_name: d[coord_name] for coord_name in coord_names
-        }, name=n)
+        coords = pd.Series(
+            {coord_name: d[coord_name] for coord_name in coord_names}, name=n
+        )
+
     return coords
 
     coords = generate_feature_dataframe(G, funcs=[extract_coords])
@@ -79,4 +81,6 @@ def inverse_distance_matrix(G, power) -> xr.DataArray:
     distmat = (distmat + I) ** power
     distmat = 1 / distmat
     distamt -= I
-    return format_adjacency(G, distmat, f"inverse_distance_matrix_power_{power}")
+    return format_adjacency(
+        G, distmat, f"inverse_distance_matrix_power_{power}"
+    )

--- a/graphein/diffusion.py
+++ b/graphein/diffusion.py
@@ -6,14 +6,15 @@ Each of the functions here accepts a NetworkX graph object
 and returns a 2D xarray.
 These arrays can then be stacked to generate a diffusion tensor.
 """
+from typing import Dict
+
 import networkx as nx
+import numpy as np
+import pandas as pd
 import xarray as xr
 
 from .features.edges.distance import compute_distmat
 from .utils import format_adjacency, generate_feature_dataframe
-import numpy as np
-from typing import Dict
-import pandas as pd
 
 
 def identity_matrix(G: nx.Graph) -> xr.DataArray:

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -231,6 +231,7 @@ def calculate_centroid_positions(
 
 
 def compute_node_metadata(G: nx.Graph, funcs: List[Callable]) -> pd.Series:
+    # TODO: This needs a clearer function definition.
     for func in funcs:
         for n, d in G.nodes(data=True):
             metadata = func(n, d)

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -80,6 +80,7 @@ def process_dataframe(
     :return: A protein dataframe that can be consumed by
         other graph construction functions.
     """
+    # TODO: Need to properly define what "granularity" is supposed to do.
     atoms = protein_df.df["ATOM"]
     hetatms = protein_df.df["HETATM"]
 

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -25,6 +25,8 @@ from graphein.features.edges.distance import compute_distmat
 from graphein.features.edges.intramolecular import get_contacts_df
 from graphein.protein.config import ProteinGraphConfig
 
+from ..utils import annotate_graph_metadata, annotate_node_metadata
+
 # from graphein.protein.visualisation import protein_graph_plot_3d
 
 
@@ -228,16 +230,6 @@ def calculate_centroid_positions(
     return centroids
 
 
-def annotate_node_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    """
-    Annotates node metadata
-    """
-    for func in funcs:
-        for n, d in G.nodes(data=True):
-            func(n, d)
-    return G
-
-
 def compute_node_metadata(G: nx.Graph, funcs: List[Callable]) -> pd.Series:
     for func in funcs:
         for n, d in G.nodes(data=True):
@@ -245,18 +237,8 @@ def compute_node_metadata(G: nx.Graph, funcs: List[Callable]) -> pd.Series:
     return metadata
 
 
-def annotate_edge_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    raise NotImplementedError
-
-
 def compute_edge_metadata(G: nx.Graph, funcs: List[Callable]) -> pd.Series:
     raise NotImplementedError
-
-
-def annotate_graph_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    for func in funcs:
-        func(G)
-    return G
 
 
 def compute_edges(

--- a/graphein/rna/edges.py
+++ b/graphein/rna/edges.py
@@ -1,0 +1,68 @@
+"""Functions to compute edges for an RNA secondary structure graph"""
+# %%
+# Graphein
+# Author: Arian Jamasb <arian@jamasb.io>, Emmanuele Rossi
+# License: MIT
+# Project Website: https://github.com/a-r-j/graphein
+# Code Repository: https://github.com/a-r-j/graphein
+import networkx as nx
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def add_phosphodiester_bonds(G: nx.Graph) -> nx.Graph:
+    """
+    Adds phosphodiester bonds between adjacent nucleotides to an RNA secondary structure graph
+    :param G: RNA Graph to add edges to
+    :type G: nx.Graph
+    :return: RNA graph with phosphodiester_bond edges added
+    :rtype: nx.Graph
+    """
+    # Iterate over dotbracket to build connectivity
+    bases = []
+    for i, c in enumerate(G.graph["dotbracket"]):
+        # Add adjacent edges (phosphodiester_bonds)
+        if i > 0:
+            G.add_edge(i, i - 1, attr="phosphodiester_bond", color="b")
+    log.debug("Added phosphodiester bonds as edges")
+    return G
+
+
+def add_base_pairing_interactions(G: nx.Graph) -> nx.Graph:
+    """
+    Adds base_pairing interactions between nucleotides to an RNA secondary structure graph
+    :param G: RNA Graph to add edges to
+    :type G: nx.Graph
+    :return: RNA graph with base_pairing edges added
+    :rtype: nx.Graph
+    """
+    # Iterate over dotbracket to build connectivity
+    bases = []
+    for i, c in enumerate(G.graph["dotbracket"]):
+        # Add base_pairing interactions
+        if c == "(":
+            bases.append(i)
+        elif c == ")":
+            neighbor = bases.pop()
+            G.add_edge(i, neighbor, attr="base_pairing", color="r")
+        elif c == ".":
+            continue
+        else:
+            raise ValueError("Input is not in dot-bracket notation!")
+        log.debug("Added base_pairing interactions as edges")
+    return G
+
+
+def add_all_dotbracket_edges(G: nx.Graph) -> nx.Graph:
+    """
+    Adds phosphodiester bonds between adjacent nucleotides and base_pairing interactions to an RNA secondary structure graph
+    :param G: RNA Graph to add edges to
+    :type G: nx.Graph
+    :return: RNA graph with phosphodiester_bond and base_pairing edges added
+    :rtype: nx.Graph
+    """
+    # Iterate over dotbracket to build connectivity
+    G = add_phosphodiester_bonds(G)
+    G = add_base_pairing_interactions(G)
+    return G

--- a/graphein/rna/edges.py
+++ b/graphein/rna/edges.py
@@ -5,8 +5,9 @@
 # License: MIT
 # Project Website: https://github.com/a-r-j/graphein
 # Code Repository: https://github.com/a-r-j/graphein
-import networkx as nx
 import logging
+
+import networkx as nx
 
 log = logging.getLogger(__name__)
 

--- a/graphein/rna/graphs.py
+++ b/graphein/rna/graphs.py
@@ -10,6 +10,13 @@ from typing import Callable, List, Optional
 
 import networkx as nx
 
+from ..utils import (
+    annotate_edge_metadata,
+    annotate_graph_metadata,
+    annotate_node_metadata,
+    compute_edges,
+)
+
 log = logging.getLogger(__name__)
 
 RNA_BASES = ["A", "U", "G", "C", "I"]
@@ -30,72 +37,36 @@ SUPPORTED_DOTBRACKET_NOTATION = ["(", ".", ")"]
 # Todo checking of valid base-parings
 
 
-def annotate_node_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    """
-    Annotates nodes with metadata
-    :param G: RNA Secondary structure graph to add node metadata to
-    :type G: nx.Graph
-    :param funcs: List of node metadata annotation functions
-    :type funcs: List[Callable]
-    :return: RNA secondary structure graph with node metadata added
-    :rtype: nx.Graph
-    """
-    for func in funcs:
-        for n, d in G.nodes(data=True):
-            func(n, d)
-    return G
+def validate_rna_sequence(s: str):
+    letters_used = set(s)
+    if not letters_used.issubset(RNA_BASES):
+        offending_letter = letters_used.difference(RNA_BASES)
+        position = s.index(offending_letter)
+        raise ValueError(
+            f"Invalid letter {offending_letter} found at position {position} in the sequence {s}."
+        )
 
 
-def annotate_graph_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    """
-    Annotates graph with graph-level metadata
-    :param G: RNA Secondary structure graph to add graph-level metadata to
-    :type G: nx.Graph
-    :param funcs: List of graph metadata annotation functions
-    :type funcs: List[Callable]
-    :return: RNA secondary structure graph with node metadata added
-    :rtype: nx.Graph
-    """
-    for func in funcs:
-        func(G)
-    return G
+def validate_lengths(db: str, seq: str):
+    if len(db) != len(seq):
+        raise ValueError(
+            f"Length of dotbracket ({len(db)}) does not match length of sequence ({len(seq)})."
+        )
 
 
-def annotate_edge_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
-    """
-    Annotates RNA Secondary Structure graph edges with edge metadata
-    :param G: RNA Secondary structure graph to add edge metadata to
-    :type G: nx.Graph
-    :param funcs: List of edge metadata annotation functions
-    :type funcs: List[Callable]
-    :return: RNA secondary structure graph with edge metadata added
-    :rtype: nx.Graph
-    """
-    for func in funcs:
-        for u, v, d in G.edges(data=True):
-            func(u, v, d)
-    return G
+def sanitize_dotbracket(db: str) -> str:
+    """Sanitize dotbracket string.
 
-
-def compute_edges(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    This ensures that it only has supported letters.
     """
-    Computes edges for an RNA Secondary structure graph from a list of edge construction functions
-    :param G: RNA Secondary Structure graph to add features to
-    :type G: nx.Graph
-    :param funcs: List of edge construction functions
-    :type funcs: List[Callable]
-    :return: RNA Secondary structure graph with edges added
-    :rtype: nx.Graph
-    """
-    for func in funcs:
-        func(G)
-    return G
+    db = "".join(i if i in SUPPORTED_DOTBRACKET_NOTATION else "." for i in db)
+    return db
 
 
 def construct_rna_graph(
     dotbracket: Optional[str],
     sequence: Optional[str],
-    edge_construction_funcs: [List[Callable]],
+    edge_construction_funcs: List[Callable],
     edge_annotation_funcs: Optional[List[Callable]] = None,
     node_annotation_funcs: Optional[List[Callable]] = None,
     graph_annotation_funcs: Optional[List[Callable]] = None,
@@ -103,46 +74,25 @@ def construct_rna_graph(
     """
     Constructs an RNA secondary structure graph from dotbracket notation
     :param dotbracket: Dotbracket notation representation of secondary structure
-    :type dotbracket: str
     :param sequence: Corresponding sequence RNA bases
-    :type sequence: Optional[str]
     :param edge_construction_funcs: List of edge construction functions
-    :type edge_construction_funcs: [List[Callable]]
     :param edge_annotation_funcs: List of edge metadata annotation functions
-    :type edge_annotation_funcs: Optional[List[Callable]], default = None
     :param node_annotation_funcs: List of node metadata annotation functions
-    :type node_annotation_funcs: Optional[List[Callable]], default = None
     :param graph_annotation_funcs: List of graph metadata annotation functions
-    :type graph_annotation_funcs: Optiona[List[Callable]], default = None
     :return: nx.Graph of RNA secondary structure
-    :rtype: nx.Graph
     """
     G = nx.Graph()
 
+    # Build node IDs first.
+    node_ids = (
+        list(range(len(sequence)))
+        if sequence
+        else list(range(len(dotbracket)))
+    )
+
     # Check sequence and dotbracket lengths match
     if dotbracket and sequence:
-        assert len(dotbracket) == len(
-            sequence
-        ), "Sequence and dotbracket lengths must match"
-
-    # Assign dotbracket as graph metadata
-    if dotbracket:
-        # Perform substitution on dotbracket sequence
-        dotbracket = [
-            i if i in SUPPORTED_DOTBRACKET_NOTATION else "."
-            for i in dotbracket
-        ]
-        G.graph["dotbracket"] = dotbracket
-        node_ids = [i for i in range(len(dotbracket))]
-
-    # Assign sequence as graph metadata
-    if sequence:
-        # Check sequence contains valid characters
-        assert [
-            i in RNA_BASES for i in sequence
-        ], "Sequence must contain valid RNA bases: {A, U, G, C, I}"
-        G.graph["sequence"] = sequence
-        node_ids = [i for i in range(len(sequence))]
+        validate_lengths(dotbracket, sequence)
 
     # add nodes
     G.add_nodes_from(node_ids)
@@ -150,22 +100,22 @@ def construct_rna_graph(
 
     # Add dotbracket symbol if dotbracket is provided
     if dotbracket:
+        dotbracket = sanitize_dotbracket(dotbracket)
+        G.graph["dotbracket"] = dotbracket
+
         nx.set_node_attributes(
             G,
-            dict(zip(node_ids, [i for i in dotbracket])),
+            dict(zip(node_ids, dotbracket)),
             "dotbracket_symbol",
         )
 
     # Add nucleotide base info if sequence is provided
     if sequence:
-        nx.set_node_attributes(
-            G, dict(zip(node_ids, [i for i in sequence])), "nucleotide"
-        )
-        nx.set_node_attributes(
-            G,
-            dict(zip(node_ids, [RNA_BASE_COLORS[i] for i in sequence])),
-            "color",
-        )
+        validate_rna_sequence(sequence)
+        G.graph["sequence"] = sequence
+        nx.set_node_attributes(G, dict(zip(node_ids, sequence)), "nucleotide")
+        colors = [RNA_BASE_COLORS[i] for i in sequence]
+        nx.set_node_attributes(G, dict(zip(node_ids, colors)), "color")
 
     # Annotate additional graph metadata
     if graph_annotation_funcs is not None:

--- a/graphein/rna/graphs.py
+++ b/graphein/rna/graphs.py
@@ -5,9 +5,10 @@
 # License: MIT
 # Project Website: https://github.com/a-r-j/graphein
 # Code Repository: https://github.com/a-r-j/graphein
-from typing import Optional, List, Callable
-import networkx as nx
 import logging
+from typing import Callable, List, Optional
+
+import networkx as nx
 
 log = logging.getLogger(__name__)
 
@@ -186,10 +187,11 @@ def construct_rna_graph(
 
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
+
     from graphein.rna.edges import (
+        add_all_dotbracket_edges,
         add_base_pairing_interactions,
         add_phosphodiester_bonds,
-        add_all_dotbracket_edges,
     )
 
     edge_funcs_1 = [add_base_pairing_interactions, add_phosphodiester_bonds]

--- a/graphein/rna/graphs.py
+++ b/graphein/rna/graphs.py
@@ -1,0 +1,219 @@
+"""Functions for working with RNA Secondary Structure Graphs"""
+# %%
+# Graphein
+# Author: Arian Jamasb <arian@jamasb.io>, Emmanuele Rossi
+# License: MIT
+# Project Website: https://github.com/a-r-j/graphein
+# Code Repository: https://github.com/a-r-j/graphein
+from typing import Optional, List, Callable
+import networkx as nx
+import logging
+
+log = logging.getLogger(__name__)
+
+RNA_BASES = ["A", "U", "G", "C", "I"]
+
+RNA_BASE_COLORS = {
+    "A": "r",
+    "U": "b",
+    "G": "g",
+    "C": "y",
+    "I": "m",
+}
+
+SUPPORTED_DOTBRACKET_NOTATION = ["(", ".", ")"]
+
+# Todo Pseudoknots: Some secondary structure databases include other characters ( [] , {}, <>, a, etc...)
+#  to represent pairing in pseudoknots.
+
+# Todo checking of valid base-parings
+
+
+def annotate_node_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates nodes with metadata
+    :param G: RNA Secondary structure graph to add node metadata to
+    :type G: nx.Graph
+    :param funcs: List of node metadata annotation functions
+    :type funcs: List[Callable]
+    :return: RNA secondary structure graph with node metadata added
+    :rtype: nx.Graph
+    """
+    for func in funcs:
+        for n, d in G.nodes(data=True):
+            func(n, d)
+    return G
+
+
+def annotate_graph_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates graph with graph-level metadata
+    :param G: RNA Secondary structure graph to add graph-level metadata to
+    :type G: nx.Graph
+    :param funcs: List of graph metadata annotation functions
+    :type funcs: List[Callable]
+    :return: RNA secondary structure graph with node metadata added
+    :rtype: nx.Graph
+    """
+    for func in funcs:
+        func(G)
+    return G
+
+
+def annotate_edge_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates RNA Secondary Structure graph edges with edge metadata
+    :param G: RNA Secondary structure graph to add edge metadata to
+    :type G: nx.Graph
+    :param funcs: List of edge metadata annotation functions
+    :type funcs: List[Callable]
+    :return: RNA secondary structure graph with edge metadata added
+    :rtype: nx.Graph
+    """
+    for func in funcs:
+        for u, v, d in G.edges(data=True):
+            func(u, v, d)
+    return G
+
+
+def compute_edges(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Computes edges for an RNA Secondary structure graph from a list of edge construction functions
+    :param G: RNA Secondary Structure graph to add features to
+    :type G: nx.Graph
+    :param funcs: List of edge construction functions
+    :type funcs: List[Callable]
+    :return: RNA Secondary structure graph with edges added
+    :rtype: nx.Graph
+    """
+    for func in funcs:
+        func(G)
+    return G
+
+
+def construct_rna_graph(
+    dotbracket: Optional[str],
+    sequence: Optional[str],
+    edge_construction_funcs: [List[Callable]],
+    edge_annotation_funcs: Optional[List[Callable]] = None,
+    node_annotation_funcs: Optional[List[Callable]] = None,
+    graph_annotation_funcs: Optional[List[Callable]] = None,
+) -> nx.Graph:
+    """
+    Constructs an RNA secondary structure graph from dotbracket notation
+    :param dotbracket: Dotbracket notation representation of secondary structure
+    :type dotbracket: str
+    :param sequence: Corresponding sequence RNA bases
+    :type sequence: Optional[str]
+    :param edge_construction_funcs: List of edge construction functions
+    :type edge_construction_funcs: [List[Callable]]
+    :param edge_annotation_funcs: List of edge metadata annotation functions
+    :type edge_annotation_funcs: Optional[List[Callable]], default = None
+    :param node_annotation_funcs: List of node metadata annotation functions
+    :type node_annotation_funcs: Optional[List[Callable]], default = None
+    :param graph_annotation_funcs: List of graph metadata annotation functions
+    :type graph_annotation_funcs: Optiona[List[Callable]], default = None
+    :return: nx.Graph of RNA secondary structure
+    :rtype: nx.Graph
+    """
+    G = nx.Graph()
+
+    # Check sequence and dotbracket lengths match
+    if dotbracket and sequence:
+        assert len(dotbracket) == len(
+            sequence
+        ), "Sequence and dotbracket lengths must match"
+
+    # Assign dotbracket as graph metadata
+    if dotbracket:
+        # Perform substitution on dotbracket sequence
+        dotbracket = [
+            i if i in SUPPORTED_DOTBRACKET_NOTATION else "."
+            for i in dotbracket
+        ]
+        G.graph["dotbracket"] = dotbracket
+        node_ids = [i for i in range(len(dotbracket))]
+
+    # Assign sequence as graph metadata
+    if sequence:
+        # Check sequence contains valid characters
+        assert [
+            i in RNA_BASES for i in sequence
+        ], "Sequence must contain valid RNA bases: {A, U, G, C, I}"
+        G.graph["sequence"] = sequence
+        node_ids = [i for i in range(len(sequence))]
+
+    # add nodes
+    G.add_nodes_from(node_ids)
+    log.debug(f"Added {len(node_ids)} nodes")
+
+    # Add dotbracket symbol if dotbracket is provided
+    if dotbracket:
+        nx.set_node_attributes(
+            G,
+            dict(zip(node_ids, [i for i in dotbracket])),
+            "dotbracket_symbol",
+        )
+
+    # Add nucleotide base info if sequence is provided
+    if sequence:
+        nx.set_node_attributes(
+            G, dict(zip(node_ids, [i for i in sequence])), "nucleotide"
+        )
+        nx.set_node_attributes(
+            G,
+            dict(zip(node_ids, [RNA_BASE_COLORS[i] for i in sequence])),
+            "color",
+        )
+
+    # Annotate additional graph metadata
+    if graph_annotation_funcs is not None:
+        G = annotate_graph_metadata(G, graph_annotation_funcs)
+
+    # Annotate additional node metadata
+    if node_annotation_funcs is not None:
+        G = annotate_node_metadata(G, node_annotation_funcs)
+
+    # Add edges
+    G = compute_edges(G, edge_construction_funcs)
+
+    # Annotate additional edge metadata
+    if edge_annotation_funcs is not None:
+        G = annotate_edge_metadata(G, edge_annotation_funcs)
+
+    return G
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    from graphein.rna.edges import (
+        add_base_pairing_interactions,
+        add_phosphodiester_bonds,
+        add_all_dotbracket_edges,
+    )
+
+    edge_funcs_1 = [add_base_pairing_interactions, add_phosphodiester_bonds]
+    edge_funcs_2 = [add_all_dotbracket_edges]
+
+    g = construct_rna_graph(
+        "((((....))))..(())",
+        "AUGAUGAUGAUGCICIAU",
+        edge_construction_funcs=edge_funcs_1,
+    )
+    h = construct_rna_graph(
+        "((((....))))..(())",
+        "AUGAUGAUGAUGCICIAU",
+        edge_construction_funcs=edge_funcs_2,
+    )
+
+    assert g.edges() == h.edges()
+
+    nx.info(g)
+
+    edge_colors = nx.get_edge_attributes(g, "color").values()
+    node_colors = nx.get_node_attributes(g, "color").values()
+
+    nx.draw(
+        g, edge_color=edge_colors, node_color=node_colors, with_labels=True
+    )
+    plt.show()

--- a/graphein/utils.py
+++ b/graphein/utils.py
@@ -2,6 +2,8 @@ from typing import Callable, List
 
 import networkx as nx
 import pandas as pd
+import numpy as np
+import xarray as xr
 
 
 def onek_encoding_unk(x, allowable_set):

--- a/graphein/utils.py
+++ b/graphein/utils.py
@@ -67,6 +67,7 @@ def compute_edges(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
         func(G)
     return G
 
+
 def generate_feature_dataframe(
     G: nx.Graph,
     funcs: List[Callable],

--- a/graphein/utils.py
+++ b/graphein/utils.py
@@ -1,3 +1,8 @@
+from typing import Callable, List
+
+import networkx as nx
+
+
 def onek_encoding_unk(x, allowable_set):
     """
     Function for one hot encoding
@@ -8,3 +13,55 @@ def onek_encoding_unk(x, allowable_set):
     # if x not in allowable_set:
     #    x = allowable_set[-1]
     return [x == s for s in allowable_set]
+
+
+def annotate_graph_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates graph with graph-level metadata
+
+    :param G: Graph on which to add graph-level metadata to
+    :param funcs: List of graph metadata annotation functions
+    :return: Graph on which with node metadata added
+    """
+    for func in funcs:
+        func(G)
+    return G
+
+
+def annotate_edge_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates Graph edges with edge metadata
+    :param G: Graph to add edge metadata to
+    :param funcs: List of edge metadata annotation functions
+    :return: Graph with edge metadata added
+    """
+    for func in funcs:
+        for u, v, d in G.edges(data=True):
+            func(u, v, d)
+    return G
+
+
+def annotate_node_metadata(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Annotates nodes with metadata
+    :param G: Graph to add node metadata to
+    :param funcs: List of node metadata annotation functions
+    :return: Graph with node metadata added
+    """
+    for func in funcs:
+        for n, d in G.nodes(data=True):
+            func(n, d)
+    return G
+
+
+def compute_edges(G: nx.Graph, funcs: List[Callable]) -> nx.Graph:
+    """
+    Computes edges for an Graph from a list of edge construction functions
+
+    :param G: Graph to add features to
+    :param funcs: List of edge construction functions
+    :return: Graph with edges added
+    """
+    for func in funcs:
+        func(G)
+    return G

--- a/graphein/utils.py
+++ b/graphein/utils.py
@@ -1,8 +1,8 @@
 from typing import Callable, List
 
 import networkx as nx
-import pandas as pd
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ use_parentheses = true
 # super good for guaranteeing that there's docs!
 [tool.interrogate]
 exclude = ["setup.py", "docs", "build", "nbconvert_config.py"]
-fail-under = 61.7
+fail-under = 66.2
 ignore-init-method = true
 ignore-init-module = true
 ignore-module = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ include_trailing_comma = true
 line_length = 79 # match our custom config above
 multi_line_output = 3
 src_paths = ["graphein", "test"]
+float_to_top = true
 use_parentheses = true
 
 # Can reinstate later: Measures docstring coverage,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ use_parentheses = true
 # super good for guaranteeing that there's docs!
 [tool.interrogate]
 exclude = ["setup.py", "docs", "build", "nbconvert_config.py"]
-fail-under = 66.2
+fail-under = 66.1
 ignore-init-method = true
 ignore-init-module = true
 ignore-module = false


### PR DESCRIPTION
Ported the RNA graph construction to the new functional API.

A few things that will be useful elsewhere (will make additional issues):

* I added a `annotate_edge_metadata` function that behaves similarly to the `annotate_graph_metadata` and `annotate_node_metadata` functions in `graphein.protein.graphs`. There is some code duplication here, but I'm happy to keep it until we settle on code structure.

* The control flow in `construct_rna_graph` is a bit messy as I'm trying to leave it open to constructing a graph with either a sequence, a dotbracket string or both. Any ideas here would great!

* Again in `construct_rna_graph`, sequencing the annotation functions might be important for users that write their own metadata annotation functions. E.g. you might want to use some node properties to annotate some of your edges and you might also want to use some edge properties to annotate your nodes. Obviously, this is less of an issue with the lower-level API, but if we don't want to provide complete control over this (could be messy) at this level we should give some thought to the sequencing that will keep most people happy.


Todos:

* We currently don't support pseudoknots: non-standard dotbracket symbols are converted to `.`
* We could implement some checking of the validity of base pairing interactions