### PR TITLE
RNA base pairing checks and pseudoknots

### DIFF
--- a/graphein/rna/edges.py
+++ b/graphein/rna/edges.py
@@ -9,7 +9,26 @@ import logging
 
 import networkx as nx
 
+from .graphs import CANONICAL_BASE_PAIRINGS, WOBBLE_BASE_PAIRINGS
+
 log = logging.getLogger(__name__)
+
+
+def check_base_pairing_type(base_1: str, base_2: str) -> str:
+    """
+    Checks type and validity of base pairing interactions.
+
+    :param base_1: str RNA Base letter for base 1
+    :param base_2: str RNA base letter for base 2
+    :return: string referencing the type of base pairing
+    """
+    try:
+        if base_2 in CANONICAL_BASE_PAIRINGS[base_1]:
+            return "canonical"
+        elif base_2 in WOBBLE_BASE_PAIRINGS[base_1]:
+            return "wobble"
+    except:
+        return "invalid"
 
 
 def add_phosphodiester_bonds(G: nx.Graph) -> nx.Graph:
@@ -38,6 +57,12 @@ def add_base_pairing_interactions(G: nx.Graph) -> nx.Graph:
     :return: RNA graph with base_pairing edges added
     :rtype: nx.Graph
     """
+    # Check sequence is used
+    if "sequence" in G.graph.keys():
+        check_base_pairing = True
+    else:
+        check_base_pairing = False
+
     # Iterate over dotbracket to build connectivity
     bases = []
     for i, c in enumerate(G.graph["dotbracket"]):
@@ -46,12 +71,82 @@ def add_base_pairing_interactions(G: nx.Graph) -> nx.Graph:
             bases.append(i)
         elif c == ")":
             neighbor = bases.pop()
-            G.add_edge(i, neighbor, attr="base_pairing", color="r")
-        elif c == ".":
+
+            if check_base_pairing:
+                pairing_type = check_base_pairing_type(
+                    G.nodes[i]["nucleotide"], G.nodes[neighbor]["nucleotide"]
+                )
+            else:
+                pairing_type = "unknown"
+
+            G.add_edge(
+                i,
+                neighbor,
+                attr="base_pairing",
+                pairing_type=pairing_type,
+                color="r",
+            )
+        elif c in [".", "[", "]", "{", "}", "<", ">"]:
             continue
         else:
             raise ValueError("Input is not in dot-bracket notation!")
         log.debug("Added base_pairing interactions as edges")
+    return G
+
+
+def add_pseudoknots(G: nx.Graph) -> nx.Graph:
+    """
+    Adds pseudoknots nucleotides to an RNA secondary structure graph
+    :param G: RNA Graph to add edges to
+    :type G: nx.Graph
+    :return: RNA graph with pseudoknot edges added
+    :rtype: nx.Graph
+    """
+    # Check sequence is used
+    if "sequence" in G.graph.keys():
+        check_base_pairing = True
+    else:
+        check_base_pairing = False
+
+    # Iterate over dotbracket to build connectivity
+    knot_bases_1 = []  # for [[[]]] knots
+    knot_bases_2 = []  # for {{{}}} knots
+    knot_bases_3 = []  # for <<<>>> knots
+
+    for i, c in enumerate(G.graph["dotbracket"]):
+        if c in ["[", "{", "<"]:
+            if c == "[":
+                knot_bases_1.append(i)
+            elif c == "{":
+                knot_bases_2.append(i)
+            elif c == "<":
+                knot_bases_3.append(i)
+        elif c in ["]", "}", ">"]:
+            if c == "]":
+                neighbor = knot_bases_1.pop()
+            elif c == "}":
+                neighbor = knot_bases_2.pop()
+            elif c == ">":
+                neighbor = knot_bases_3.pop()
+
+            if check_base_pairing:
+                pairing_type = check_base_pairing_type(
+                    G.nodes[i]["nucleotide"], G.nodes[neighbor]["nucleotide"]
+                )
+            else:
+                pairing_type = "unknown"
+            G.add_edge(
+                i,
+                neighbor,
+                attr="pseudoknot",
+                pairing_type=pairing_type,
+                color="g",
+            )
+        elif c in ["(", ")", "."]:
+            continue
+        else:
+            raise ValueError("Input is not in dot-bracket notation!")
+        log.debug("Added pseudoknot interactions as edges")
     return G
 
 
@@ -66,4 +161,5 @@ def add_all_dotbracket_edges(G: nx.Graph) -> nx.Graph:
     # Iterate over dotbracket to build connectivity
     G = add_phosphodiester_bonds(G)
     G = add_base_pairing_interactions(G)
+    G = add_pseudoknots(G)
     return G

--- a/graphein/utils/utils.py
+++ b/graphein/utils/utils.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from yaml import unsafe_load
 from typing import Any, Callable, Iterable, List
 
 import networkx as nx
@@ -17,6 +16,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from Bio.Data.IUPACData import protein_letters_3to1
+from yaml import unsafe_load
 
 
 def onek_encoding_unk(
@@ -358,9 +358,11 @@ def parse_config(path: Path):
 
 def parse_protein_graph_config(config_dict):
     from graphein.protein.config import ProteinGraphConfig
+
     config = ProteinGraphConfig(**config_dict)
     print(config)
     return config
+
 
 def parse_dssp_config(config_dict):
     raise NotImplementedError


### PR DESCRIPTION
Resolves #32 

1. Adds checks for base pairing validity (incl. wobble base pairing)
2. Supports parsing of pseudoknot dotbracket notations `"[", "]", "{", "}", "<", ">"]
