### PR TITLE
WIP: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM pytorch/pytorch:1.7.1-cuda11.0-cudnn8-runtime
+
+RUN apt-get update \
+    && apt-get -y install build-essential ffmpeg libsm6 libxext6 wget git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CONDA_ALWAYS_YES=true
+
+WORKDIR /tmp
+RUN git clone https://www.github.com/a-r-j/graphein
+
+WORKDIR /tmp/graphein
+RUN conda env create -f environment.yml
+SHELL ["conda", "run", "-n", "graphein", "/bin/bash", "-c"]
+RUN pip install -e .
+RUN python -m ipykernel install --user --name=graphein
+
+RUN conda install -c conda-forge libgcc-ng
+RUN conda install scipy scikit-learn matplotlib pandas cython ipykernel
+RUN pip install ticc==0.1.4
+
+# Set up vmd-python library
+RUN conda install -c conda-forge vmd-python
+# RUN conda install -c https://conda.anaconda.org/rbetz vmd-python
+
+# Set up getcontacts library
+RUN git clone https://github.com/getcontacts/getcontacts.git
+ENV PATH /getcontacts:$PATH
+
+RUN conda install -c fvcore -c iopath -c conda-forge fvcore iopath
+# RUN conda install -c pytorch pytorch
+RUN conda install -c pytorch3d pytorch3d
+RUN conda install -c dglteam dgl
+
+RUN export TORCH=1.7.1 \
+    && export CUDA=cu110 \
+    && pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
+    && pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
+    && pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
+    && pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
+    && pip install torch-geometric
+
+RUN pip install --upgrade numpy scipy pandas
+
+RUN mkdir -p /opt/notebooks
+
+EXPOSE 8888
+ENTRYPOINT ["conda", "run", "-n", "graphein", "jupyter", "notebook", "--notebook-dir=/opt/notebooks",  "--ip='*'", "--NotebookApp.token=''", "--NotebookApp.password=''", "--port=8888",  "--no-browser", "--allow-root"]
+


### PR DESCRIPTION
#### Details

```
FROM pytorch/pytorch:1.7.1-cuda11.0-cudnn8-runtime
```
I initially started from Ubuntu/Debian base images but quickly found that installing CUDA and the corresponding version of Pytorch can be troublesome, thus I opted to use the official Pytorch images as they come with CUDA, Pytorch and conda installed. 

```
RUN apt-get update \
    && apt-get -y install build-essential ffmpeg libsm6 libxext6 wget git \
    && rm -rf /var/lib/apt/lists/*
```
These dependencies are required prerequisites.

```
ENV CONDA_ALWAYS_YES=true
```
This is simply sets the `-y` flag by default when installing Conda libs.

```
SHELL ["conda", "run", "-n", "graphein", "/bin/bash", "-c"]
```
There appear to be a couple of ways to enable a Conda environment in a Dockerfile, for a complete explanation of this approach please see this [article](https://pythonspeed.com/articles/activate-conda-dockerfile/).

```
RUN python -m ipykernel install --user --name=graphein
```
This simply installs ipykernel and makes the graphein Conda environment available within Jupiter notebooks.

```
RUN export TORCH=1.7.1 \
    && export CUDA=cu110 \
    && pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
    && pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
    && pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
    && pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html \
    && pip install torch-geometric
```
TODO: I believe it would be preferable to install `torch-geommetric` using `RUN conda install pytorch-geometric -c rusty1s -c conda-forge -v` but I haven't been able to get it to work due to libc related errors.

```
ENTRYPOINT ["conda", "run", "-n", "graphein", "jupyter", "notebook", "--notebook-dir=/opt/notebooks",  "--ip='*'", "--NotebookApp.token=''", "--NotebookApp.password=''", "--port=8888",  "--no-browser", "--allow-root"]
```
Running this Docker image starts a Jupiter notebook server without a password at localhost:8888.

#### What testing did you do to verify the changes in this PR?

I have verified that most examples from the main Graphein docs work using this setup, however further testing is advised. Especially when it comes to using CUDA. 
