### PR TITLE
Edge function fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ dmypy.json
 
 # Local test files
 datasets/examples/*
+*.ent
+*.zip
+datasets/regnetwork/human
+notebooks/lightning_logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [Packaging] - #100 adds docker support.
 
-* [Bugfixes] - #95 adds improved robustness for edge construction functions in certain edge cases. Insertions in the PDB were occasionally not picked up due to a brittle implementations. Resolves #74
+* [Bugfixes] - #95 adds improved robustness for edge construction functions in certain edge cases. Insertions in the PDB were occasionally not picked up due to a brittle implementations. Resolves #74 and #98
 
 ### 1.0.11 - 01/02/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * [Packaging] - #100 adds docker support.
 
+* [Bugfixes] - #95 adds improved robustness for edge construction functions in certain edge cases. Insertions in the PDB were occasionally not picked up due to a brittle implementations. Resolves #74
+
 ### 1.0.11 - 01/02/2022
 
 * [Improvement] - #79 Replaces `Literal` references with `typing_extensions.Literal` for Python 3.7 support.

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -144,19 +144,23 @@ def subset_structure_to_atom_type(
     )
 
 
-def remove_insertions(df: pd.DataFrame) -> pd.DataFrame:
+def remove_insertions(df: pd.DataFrame, keep: str = "first") -> pd.DataFrame:
     """
     This function removes insertions from PDB dataframes
 
     :param df: Protein Structure dataframe to remove insertions from
     :type df: pd.DataFrame
+    :param keep: Specifies which insertion to keep. Options are "first" or "last".
+    :type keep: str
     :return: Protein structure dataframe with insertions removed
     :rtype: pd.DataFrame
     """
     """Remove insertions from structure."""
-    return filter_dataframe(
-        df, by_column="alt_loc", list_of_values=["", "A"], boolean=True
-    )
+    duplicates = df.duplicated(subset=["node_id", "atom_name"], keep=keep)
+    # return filter_dataframe(
+    #    df, by_column="alt_loc", list_of_values=["", "A"], boolean=True
+    # )
+    return df[~duplicates]
 
 
 def filter_hetatms(

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -156,7 +156,9 @@ def remove_insertions(df: pd.DataFrame, keep: str = "first") -> pd.DataFrame:
     :rtype: pd.DataFrame
     """
     """Remove insertions from structure."""
-    duplicates = df.duplicated(subset=["node_id", "atom_name"], keep=keep)
+    duplicates = df.duplicated(
+        subset=["chain_id", "residue_number", "atom_name"], keep=keep
+    )
     # return filter_dataframe(
     #    df, by_column="alt_loc", list_of_values=["", "A"], boolean=True
     # )


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes for #74 

#### What does this implement/fix? Explain your changes.
Certain edge construction functions broke under edge case circumstances. These have been made more robust.

Hydrogen bond addition would fail if there were no Sulphur atoms present.
Add_aromatic edges had no default pdb_df to build edges from provided.

Additionally, altloc atoms filtering has been changed to a duplication detection scheme (duplicates with the same residueID and atom identifier are identified and the first is chosen as the node, rather than selecting only residues in ["", "A"]. This behaves more or less the same but copes with non-standard altloc naming schems such as ["B", "D"].

#### What testing did you do to verify the changes in this PR?
Tests pass. Manual verification on previously known to fail PDB examples (["1swr", "3ivc","2qbw","3e85","3wzn","2r9x"])