### PR TITLE
3.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,20 +3,20 @@ name: build
 on:
   push:
     paths-ignore:
-      - 'README.md'
-      - 'docs/**'
+      - "README.md"
+      - "docs/**"
 
   pull_request:
     paths-ignore:
-      - 'README.md'
-      - 'docs/*'
+      - "README.md"
+      - "docs/*"
 
 jobs:
   build_cpu:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
         torch: [1.6.0, 1.7.0, 1.8.0, 1.9.0]
         include:
           - torch: 1.6.0
@@ -37,17 +37,17 @@ jobs:
             torchvision: 0.10.0
             python-version: 3.9
     steps:
-        - name: Checkout repository
-          uses: actions/checkout@v2
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install PyTorch
-          run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        - name: Install Graphein
-          run: pip install -e .
-        - name: Install Dev Dependencies
-          run: pip install -r .requirements/dev.in
-        - name: Run unit tests and generate coverage report
-          run: pytest .
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Install Graphein
+        run: pip install -e .
+      - name: Install Dev Dependencies
+        run: pip install -r .requirements/dev.in
+      - name: Run unit tests and generate coverage report
+        run: pytest .

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -12,5 +12,6 @@ pyyaml>=5.1
 scikit-learn
 scipy
 tqdm
+typing_extensions
 wget
 xarray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 #### 1.0.10 - 23/12/2021
 
 * [Bug] Adds a fix for #74. Adding a disulfide bond to a protein with no disulphide bonds would fail. This was fixed by adding a check for the presence of a minimum of two CYS residues.
+
+* [Improvement] - #79 Replaces `Literal` references with `typing_extensions.Literal` for Python 3.7 support.

--- a/graphein/ml/conversion.py
+++ b/graphein/ml/conversion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, Optional, TypeVar
+from typing import List, Optional, TypeVar
 
 import networkx as nx
 import numpy as np

--- a/graphein/protein/config.py
+++ b/graphein/protein/config.py
@@ -7,9 +7,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, List, Literal, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from pydantic import BaseModel
+from typing_extensions import Literal
 
 from graphein.protein.edges.distance import add_peptide_bonds
 from graphein.protein.features.nodes.amino_acid import meiler_embedding

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     # install_requires=install_reqs,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     license="MIT",
     platforms="any",
     classifiers=[
@@ -163,6 +163,7 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: Unix",
         "Operating System :: MacOS",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #79

#### What does this implement/fix? Explain your changes.
Removes `Literal` references and replaces them with `typing_extensions.Literal` for Python 3.7 support.

#### What testing did you do to verify the changes in this PR?
Add Python 3.7 build to workflow.