### PR TITLE
[Dev] add Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.1/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.cpu.yml",
+		"docker-compose.yml"
+	],
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "graphein-cpu",
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"shardulm94.trailing-spaces",
+		"sourcery.sourcery",
+		"trond-snekvik.simple-rst",
+		"lextudio.restructuredtext",
+		"codefactor.repo-status",
+		"leonhard-s.python-sphinx-highlight",
+		"kevinrose.vsc-python-indent",
+		"njpwerner.autodocstring",
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"arianjamasb.protein-viewer",
+		"christian-kohler.path-intellisense",
+		"davidanson.vscode-markdownlint",
+		"ms-toolsai.jupyter-renderers",
+		"ms-toolsai.jupyter",
+		"oderwat.indent-rainbow",
+		"eamodio.gitlens",
+		"github.vscode-pull-request-github",
+		"coenraads.bracket-pair-colorizer-2",
+		"markis.code-coverage",
+		"reageyao.biosyntax",
+		"streetsidesoftware.code-spell-checker"
+	]
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.3'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  graphein-cpu:
+    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks,
+    # debugging) to execute as the user. Uncomment the next line if you want the entire
+    # container to run as this user instead. Note that, on Linux, you may need to
+    # ensure the UID and GID of the container user you create matches your local user.
+    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    #
+    # user: vscode
+
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary*
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - .:/workspace:cached
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock
+
+      # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+      # cap_add:
+      #   - SYS_PTRACE
+      # security_opt:
+      #   - seccomp:unconfined
+
+      # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.12 - UNRELEASED
 
 * [Packaging] - #100 adds docker support.
+* [Packaging] - #101 adds support for devcontainers for remote development.
 
 ### 1.0.11 - 01/02/2022
 


### PR DESCRIPTION
#### Reference Issues/PRs
Add Devcontainer support for Remote Development. Builds on #100 

#### What does this implement/fix? Explain your changes
Configured `.devcontainer.json` to use the `docker-compose.cpu.yml` file to build the container.

#### What testing did you do to verify the changes in this PR?
Local tests. Dockerfile & docker-compose files are included in the workflow actions.