### PR TITLE
Vector bugfix #148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [Feature] - #144 adds support for chord diagram visualisations.
 * [Feature] - #144 adds support for automagically downloading new PDB files for obsolete structures.
 * [Misc] - #144 makes visualisation functions accessible in the `graphein.protein` namespace. #138
-
+* [Bugfix] - #147 fixes error in `add_distance_threshold` introduced in v1.2.1 that would prevent the edges being added to the graph. [#146](https://github.com/a-r-j/graphein/issues/146)
 
 ### 1.2.1 - 16/3/21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [Feature] - #144 adds support for automagically downloading new PDB files for obsolete structures.
 * [Misc] - #144 makes visualisation functions accessible in the `graphein.protein` namespace. #138
 * [Bugfix] - #147 fixes error in `add_distance_threshold` introduced in v1.2.1 that would prevent the edges being added to the graph. [#146](https://github.com/a-r-j/graphein/issues/146)
+* [Bugfix] - #149 fixes a bug in `add_beta_carbon_vector` that would cause coordinates to be extracted for multiple positions if the residue has an altloc. Resolves [#148](https://github.com/a-r-j/graphein/issues/148)
 
 ### 1.2.1 - 16/3/21
 

--- a/graphein/protein/edges/distance.py
+++ b/graphein/protein/edges/distance.py
@@ -480,9 +480,10 @@ def add_distance_threshold(
     )
     dist_mat = compute_distmat(pdb_df)
     interacting_nodes = get_interacting_atoms(threshold, distmat=dist_mat)
-    interacting_nodes = zip(interacting_nodes[0], interacting_nodes[1])
+    interacting_nodes = list(zip(interacting_nodes[0], interacting_nodes[1]))
 
-    log.info(f"Found: {len(list(interacting_nodes))} distance edges")
+    log.info(f"Found: {len(interacting_nodes)} distance edges")
+    count = 0
     for a1, a2 in interacting_nodes:
         n1 = G.graph["pdb_df"].loc[a1, "node_id"]
         n2 = G.graph["pdb_df"].loc[a2, "node_id"]
@@ -491,16 +492,20 @@ def add_distance_threshold(
         n1_position = G.graph["pdb_df"].loc[a1, "residue_number"]
         n2_position = G.graph["pdb_df"].loc[a2, "residue_number"]
 
-        condition_1 = n1_chain != n2_chain
+        condition_1 = n1_chain == n2_chain
         condition_2 = (
-            abs(n1_position - n2_position) > long_interaction_threshold
+            abs(n1_position - n2_position) < long_interaction_threshold
         )
 
-        if condition_1 or condition_2:
+        if not (condition_1 and condition_2):
+            count += 1
             if G.has_edge(n1, n2):
                 G.edges[n1, n2]["kind"].add("distance_threshold")
             else:
                 G.add_edge(n1, n2, kind={"distance_threshold"})
+    log.info(
+        f"Added {count} distance edges. ({len(list(interacting_nodes)) - count} removed by LIN)"
+    )
 
 
 def add_k_nn_edges(

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -78,9 +78,12 @@ def add_beta_carbon_vector(
     :param reverse: Reverse vector. Defaults to ``False``.
     :type reverse: bool
     """
+    # Get or compute R-Group DF
+    if "rgroup_df" not in g.graph.keys():
+        g.graph["rgroup_df"] = compute_rgroup_dataframe(g.graph["raw_pdb_df"])
 
     c_beta_coords = filter_dataframe(
-        g.graph["raw_pdb_df"], "atom_name", ["CB"], boolean=True
+        g.graph["rgroup_df"], "atom_name", ["CB"], boolean=True
     )
     c_beta_coords.index = c_beta_coords["node_id"]
 

--- a/tests/protein/nodes/features/test_geometry.py
+++ b/tests/protein/nodes/features/test_geometry.py
@@ -67,6 +67,14 @@ def test_add_beta_carbon_vector():
             np.testing.assert_almost_equal(
                 cb_true, d["coords"] + d["c_beta_vector"]
             )
+    # Test altloc handling
+    g = construct_graph(config=config, pdb_code="6rew")
+    for n, d in g.nodes(data=True):
+        assert d["c_beta_vector"].shape == (3,)
+
+    g = construct_graph(config=config, pdb_code="7w9w")
+    for n, d in g.nodes(data=True):
+        assert d["c_beta_vector"].shape == (3,)
 
 
 def test_add_sidechain_vector():


### PR DESCRIPTION
#### Reference Issues/PRs
#148

#### What does this implement/fix? Explain your changes
Changes C-beta vector computation to use pre-computed rgroup df for subsetting. Prevents errors where multiple vectors would be computed for residues with altlocs.

#### What testing did you do to verify the changes in this PR?
Add example-based tests for problematic PDBs

