### PR TITLE
fix `nodes` index access for `coords`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.5.2
+
+* [Bugfix] - [#206](https://github.com/a-r-j/graphein/pull/206) Fixes `KeyError` when using `graphein.protein.edges.distance.node_coords`
+
+
 ### 1.5.1
 
 #### Protein

--- a/graphein/protein/edges/distance.py
+++ b/graphein/protein/edges/distance.py
@@ -1194,10 +1194,7 @@ def node_coords(G: nx.Graph, n: str) -> Tuple[float, float, float]:
     :return: Tuple of coordinates ``(x, y, z)``
     :rtype: Tuple[float, float, float]
     """
-    x = G.nodes[n]["x_coord"]
-    y = G.nodes[n]["y_coord"]
-    z = G.nodes[n]["z_coord"]
-
+    x, y, z = tuple(G.nodes[n]["coords"])
     return x, y, z
 
 


### PR DESCRIPTION
fixes `KeyError` when using `graphein.protein.edges.distance.node_coords` 