### PR TITLE
fix peptide bonds for all atom graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ### 1.5.3 - UNRELEASED
 
+
 #### Improvements
 * [Logging] - [#221](https://github.com/a-r-j/graphein/pull/221) Adds global control of logging with `graphein.verbose(enabled=False)`.
 * [Logging] - [#242](https://github.com/a-r-j/graphein/pull/242) Adds control of protein graph construction logging. Resolves [#238](https://github.com/a-r-j/graphein/issues/238)
 
 #### Protein
-
+* [Bugfix] - [#254](https://github.com/a-r-j/graphein/pull/254) Fix peptide bond addition for all atom graphs.
 * [Bugfix] - [#223](https://github.com/a-r-j/graphein/pull/220) Fix handling of insertions in protein graphs. Insertions are now given IDs like: `A:SER:12:A`. Contribution by @manonreau.
 * [Bugfix] - [#226](https://github.com/a-r-j/graphein/pull/226) Catches failed AF2 structure downloads [#225](https://github.com/a-r-j/graphein/issues/225)
 * [Feature] - [#229](https://github.com/a-r-j/graphein/pull/220) Adds support for filtering KNN edges based on self-loops and chain membership. Contribution by @anton-bushuiev.

--- a/graphein/protein/edges/distance.py
+++ b/graphein/protein/edges/distance.py
@@ -190,6 +190,15 @@ def add_sequence_distance_edges(
             (n, v) for n, v in G.nodes(data=True) if v["chain_id"] == chain_id
         ]
 
+        # Subset to only N and C atoms in the case of full-atom 
+        # peptide bond addition
+        if G.graph["config"].granularity == "atom" and name == "peptide_bond":
+            chain_residues = [
+                (n, v)
+                for n, v in chain_residues
+                if v["atom_type"] in {"N", "C"}
+            ]
+
         # Iterate over every residue in chain
         for i, residue in enumerate(chain_residues):
             try:

--- a/graphein/protein/edges/distance.py
+++ b/graphein/protein/edges/distance.py
@@ -190,7 +190,7 @@ def add_sequence_distance_edges(
             (n, v) for n, v in G.nodes(data=True) if v["chain_id"] == chain_id
         ]
 
-        # Subset to only N and C atoms in the case of full-atom 
+        # Subset to only N and C atoms in the case of full-atom
         # peptide bond addition
         if G.graph["config"].granularity == "atom" and name == "peptide_bond":
             chain_residues = [


### PR DESCRIPTION
#### Reference Issues/PRs
#253 

#### What does this implement/fix? Explain your changes
Ensures peptide bond addition behaves correctly on all-atom graphs.


#### What testing did you do to verify the changes in this PR?
Adds a filtering step in the edge addition to only consider N and C atom nodes in the case of an all-atom graph.


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
