### PR TITLE
make pymol host and port configurable via config #261

### DIFF
--- a/graphein/protein/config.py
+++ b/graphein/protein/config.py
@@ -204,3 +204,5 @@ class ProteinMeshConfig(BaseModel):
 
     pymol_command_line_options: Optional[str] = "-cKq"
     pymol_commands: Optional[List[str]] = ["show surface"]
+    pymol_host: str = os.environ.get("PYMOL_RPCHOST", "localhost")
+    pymol_port: int = 9123

--- a/graphein/protein/meshes.py
+++ b/graphein/protein/meshes.py
@@ -14,7 +14,7 @@ from typing import List, NamedTuple, Optional, Tuple
 from loguru import logger as log
 
 from graphein.protein.config import ProteinMeshConfig
-from graphein.utils.pymol import MolViewer
+from graphein.utils.pymol import HOST, PORT, MolViewer
 from graphein.utils.utils import import_message
 
 try:
@@ -146,9 +146,9 @@ def run_pymol_commands(
     :type commands: List[str]
     """
     if host is None:
-        host = os.environ.get("PYMOL_RPCHOST", "localhost")
+        host = HOST
     if port is None:
-        port = 9123
+        port = PORT
 
     pymol = MolViewer(host=host, port=port)
 

--- a/graphein/protein/meshes.py
+++ b/graphein/protein/meshes.py
@@ -98,7 +98,7 @@ def get_obj_file(
     if out_dir is None:
         out_dir = "/tmp/"
 
-    configure_pymol_session()
+    configure_pymol_session(config)
 
     # Load structure
     pymol.load(pdb_file) if pdb_file else pymol.fetch(pdb_code)


### PR DESCRIPTION
#### Reference Issues/PRs
#261 

#### What does this implement/fix? Explain your changes
Makes pymol host & port params configurable via config.


#### What testing did you do to verify the changes in this PR?
None.

#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`
