### PR TITLE
RFAM family <-> PDB structure ID mapping

### DIFF
--- a/graphein/rna/download_rfam.py
+++ b/graphein/rna/download_rfam.py
@@ -5,7 +5,7 @@ import pandas as pd
 from tqdm import tqdm
 
 # RFAM API endpoint to retrieve family information
-RFAM_API_URL = 'https://rfam.org/family'
+RFAM_API_URL = "https://rfam.org/family"
 
 
 class FamilyNotFound(ValueError):
@@ -21,22 +21,24 @@ def _get_RFAM_family_df(family_id: str):
     :rtype: pd.DataFrame
     """
     # Send an HTTP GET request to retrieve the data
-    response = requests.get(f'{RFAM_API_URL}/{family_id}/structures?content-type=application/json')
+    response = requests.get(
+        f"{RFAM_API_URL}/{family_id}/structures?content-type=application/json"
+    )
 
     # Check if the request was successful (status code 200)
     if response.status_code == 200:
         # Extract the mapping from response
         data = response.json()
-        df = pd.DataFrame(data['mapping'])
+        df = pd.DataFrame(data["mapping"])
     else:
         raise FamilyNotFound(
-            f'Error occurred while retrieving family <-> structures mapping for family {family_id} (status code: {response.status_code})')
+            f"Error occurred while retrieving family <-> structures mapping for family {family_id} (status code: {response.status_code})"
+        )
 
     return df
 
 
-def _get_RFAM_family_info(family_id: str,
-                          keys: Optional[List[str]] = None):
+def _get_RFAM_family_info(family_id: str, keys: Optional[List[str]] = None):
     """
     Downloads DataFrame of PDB IDs annotated with RFAM families
     :param family_id: RFAM ID
@@ -47,10 +49,12 @@ def _get_RFAM_family_info(family_id: str,
     :rtype: pd.DataFrame
     """
     if keys is None:
-        keys = ['id', 'description']
+        keys = ["id", "description"]
 
     # Send an HTTP GET request to retrieve the data
-    response = requests.get(f'{RFAM_API_URL}/{family_id}?content-type=application/json')
+    response = requests.get(
+        f"{RFAM_API_URL}/{family_id}?content-type=application/json"
+    )
 
     # Check if the request was successful (status code 200)
     out = {}
@@ -58,18 +62,21 @@ def _get_RFAM_family_info(family_id: str,
         # Extract the family information from the response
         data = response.json()
         for k in keys:
-            out[k] = data['rfam'][k]
+            out[k] = data["rfam"][k]
     else:
         raise FamilyNotFound(
-            f'Error occurred while retrieving data for family {family_id} (status code: {response.status_code})')
+            f"Error occurred while retrieving data for family {family_id} (status code: {response.status_code})"
+        )
 
     return out
 
 
-def RFAM_families_df(family_ids: Optional[List[str]] = None,
-                     max_id: int = 4236,
-                     family_info_keys: Optional[List[str]] = None,
-                     verbose=True):
+def RFAM_families_df(
+    family_ids: Optional[List[str]] = None,
+    max_id: int = 4236,
+    family_info_keys: Optional[List[str]] = None,
+    verbose=True,
+):
     """
     Retrieves a DataFrame of PDB IDs annotated with RFAM families
     :param family_ids: List of families to retrieve. If None, retrieves all families: RF00001, RF00002, ..., RF04236
@@ -85,11 +92,11 @@ def RFAM_families_df(family_ids: Optional[List[str]] = None,
     :rtype: pd.DataFrame
     """
     if family_ids is None:
-        family_ids = [f'RF{i:05d}' for i in range(1, max_id + 1)]
+        family_ids = [f"RF{i:05d}" for i in range(1, max_id + 1)]
 
     families_df = None
     if verbose:
-        print('Retrieving RFAM families ...')
+        print("Retrieving RFAM families ...")
     for family_id in tqdm(family_ids):
         # Retrieve DF for a single family
         try:
@@ -97,8 +104,7 @@ def RFAM_families_df(family_ids: Optional[List[str]] = None,
             df = _get_RFAM_family_df(family_id)
 
             # Annotate family with descriptions
-            out = _get_RFAM_family_info(family_id,
-                                        keys=family_info_keys)
+            out = _get_RFAM_family_info(family_id, keys=family_info_keys)
             for k, v in out.items():
                 df[k] = v
 
@@ -114,7 +120,7 @@ def RFAM_families_df(family_ids: Optional[List[str]] = None,
     return families_df
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     family_IDs = None  # ['RF10000']
     families_df = RFAM_families_df(family_IDs)
     print(families_df)

--- a/graphein/rna/download_rfam.py
+++ b/graphein/rna/download_rfam.py
@@ -1,0 +1,80 @@
+from typing import List, Optional
+
+import requests
+import pandas as pd
+from tqdm import tqdm
+
+# RFAM API endpoint to retrieve family information
+RFAM_API_URL = 'https://rfam.org/family'
+
+
+class FamilyNotFound(ValueError):
+    pass
+
+
+def _get_RFAM_family_df(family_id: str):
+    """
+    Downloads DataFrame of PDB IDs annotated with RFAM families
+    :param family_id: RFAM ID
+    :type family_id: str
+    :return: Pandas DataFrame with information about the structures of the RFAM family
+    :rtype: pd.DataFrame
+    """
+    # Send an HTTP GET request to retrieve the data
+    response = requests.get(f'{RFAM_API_URL}/{family_id}/structures?content-type=application/json')
+
+    # Check if the request was successful (status code 200)
+    if response.status_code == 200:
+        # Extract the family names from the response
+        data = response.json()
+        df = pd.DataFrame(data['mapping'])
+    else:
+        raise FamilyNotFound(
+            f'Error occurred while retrieving data for family {family_id} (status code: {response.status_code})')
+
+    return df
+
+
+def RFAM_families_df(family_ids: Optional[List[str]] = None,
+                     max_id: int = 4236,
+                     verbose=True):
+    """
+    Retrieves a DataFrame of PDB IDs annotated with RFAM families
+    :param family_ids: List of families to retrieve. If None, retrieves all families: RF00001, RF00002, ..., RF04236
+    (we assume that RFAM family IDs are in increasing order, see: http://http.ebi.ac.uk/pub/databases/Rfam/CURRENT/fasta_files/)
+    :type family_ids: Optional[List[str]]
+    :param max_id: Maximum identifier to try. If family_ids is None, it'll query RFAM families RF00001 .. f'RF{max_id:05d}'
+    :type max_id: int
+    :param verbose: Whether to print messages
+    :type verbose: bool
+    :return: Pandas DataFrame with information about the structures of each RFAM family
+    :rtype: pd.DataFrame
+    """
+    if family_ids is None:
+        family_ids = [f'RF{i:05d}' for i in range(1, max_id + 1)]
+
+    families_df = None
+    if verbose:
+        print('Retrieving RFAM families ...')
+    for family_id in tqdm(family_ids):
+        # Retrieve DF for a single family
+        try:
+            df = _get_RFAM_family_df(family_id)
+
+            # Concatenate
+            if families_df is None:
+                families_df = df
+            else:
+                families_df = pd.concat([families_df, df])
+        except FamilyNotFound as e:
+            if verbose:
+                print(e)
+            continue
+    return families_df
+
+
+if __name__ == '__main__':
+    family_IDs = None  # ['RF10000']
+    families_df = RFAM_families_df(family_IDs)
+    print(families_df)
+    # families_df.to_csv('RFAM_families_27062023.csv', index=False)

--- a/graphein/rna/download_rfam.py
+++ b/graphein/rna/download_rfam.py
@@ -25,18 +25,50 @@ def _get_RFAM_family_df(family_id: str):
 
     # Check if the request was successful (status code 200)
     if response.status_code == 200:
-        # Extract the family names from the response
+        # Extract the mapping from response
         data = response.json()
         df = pd.DataFrame(data['mapping'])
     else:
         raise FamilyNotFound(
-            f'Error occurred while retrieving data for family {family_id} (status code: {response.status_code})')
+            f'Error occurred while retrieving family <-> structures mapping for family {family_id} (status code: {response.status_code})')
 
     return df
 
 
+def _get_RFAM_family_info(family_id: str,
+                          keys: Optional[List[str]] = None):
+    """
+    Downloads DataFrame of PDB IDs annotated with RFAM families
+    :param family_id: RFAM ID
+    :type family_id: str
+    :param keys: List of keys from the family endpoint to annotate (https://docs.rfam.org/en/latest/api.html#family)
+    :type keys: Optional[List[str]]
+    :return: Pandas DataFrame with information about the structures of the RFAM family
+    :rtype: pd.DataFrame
+    """
+    if keys is None:
+        keys = ['id', 'description']
+
+    # Send an HTTP GET request to retrieve the data
+    response = requests.get(f'{RFAM_API_URL}/{family_id}?content-type=application/json')
+
+    # Check if the request was successful (status code 200)
+    out = {}
+    if response.status_code == 200:
+        # Extract the family information from the response
+        data = response.json()
+        for k in keys:
+            out[k] = data['rfam'][k]
+    else:
+        raise FamilyNotFound(
+            f'Error occurred while retrieving data for family {family_id} (status code: {response.status_code})')
+
+    return out
+
+
 def RFAM_families_df(family_ids: Optional[List[str]] = None,
                      max_id: int = 4236,
+                     family_info_keys: Optional[List[str]] = None,
                      verbose=True):
     """
     Retrieves a DataFrame of PDB IDs annotated with RFAM families
@@ -45,6 +77,8 @@ def RFAM_families_df(family_ids: Optional[List[str]] = None,
     :type family_ids: Optional[List[str]]
     :param max_id: Maximum identifier to try. If family_ids is None, it'll query RFAM families RF00001 .. f'RF{max_id:05d}'
     :type max_id: int
+    :param family_info_keys: List of keys from the family endpoint to annotate (https://docs.rfam.org/en/latest/api.html#family)
+    :type family_info_keys: Optional[List[str]]
     :param verbose: Whether to print messages
     :type verbose: bool
     :return: Pandas DataFrame with information about the structures of each RFAM family
@@ -59,7 +93,14 @@ def RFAM_families_df(family_ids: Optional[List[str]] = None,
     for family_id in tqdm(family_ids):
         # Retrieve DF for a single family
         try:
+            # Get family <-> structures mapping
             df = _get_RFAM_family_df(family_id)
+
+            # Annotate family with descriptions
+            out = _get_RFAM_family_info(family_id,
+                                        keys=family_info_keys)
+            for k, v in out.items():
+                df[k] = v
 
             # Concatenate
             if families_df is None:

--- a/graphein/rna/download_rfam.py
+++ b/graphein/rna/download_rfam.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
-import requests
 import pandas as pd
+import requests
 from tqdm import tqdm
 
 # RFAM API endpoint to retrieve family information


### PR DESCRIPTION
Here's a script to retrieve a mapping between RFAM families and PDB structure IDs. How could this be integrated into the codebase?

There are two points that might need to be addressed:
* In the [RFAM API](https://docs.rfam.org/en/latest/api.html#family), I couldn't figure out how to get a complete list of RFAM families. Judging from [here](http://http.ebi.ac.uk/pub/databases/Rfam/CURRENT/fasta_files/), it seems that the family accession IDs follow the format: RF00001, RF00002, ..., RF04236. To retrieve all families, I introduced an argument `max_id` to specify the max ID limit (e.g. setting `max_id=4236` will stop querying after RF04236).
* Downloading the mappings for all families is time-consuming (it seems we can only query a single family at a time), it took ~40 min on my laptop. Would it be good to cache the data in `graphein/datasets`? It might be important to allow the users to re-download the data in case of updates in the RFAM database.

#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [x] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
