### PR TITLE
Fix `.requirements` reference for extras in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def read_requirements(*parts):
 INSTALL_REQUIRES = read_requirements(".requirements/base.in")
 EXTRA_REQUIRES = {
     "dev": read_requirements(".requirements/dev.in"),
-    "extras": read_requirements(".requirements/dev.in"),
+    "extras": read_requirements(".requirements/extras.in"),
 }
 # Add all requires
 all_requires = []


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes
The extras was previously referring to `.requirements/dev.in`, I have now updated to refer to the correct requirements found in `.requirements/extras.in`

#### What testing did you do to verify the changes in this PR?


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [x] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [x] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [x] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
