### PR TITLE
Fix `add_sequence_neighbour_vector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * [Bugfix] - [#305](https://github.com/a-r-j/graphein/pull/305) Fixes the construction of geometric features when beta-carbons or side chains are missing in non-glycine residues (for example in `H:CYS:104` in 3SE8).
 * [Bugfix] - [#305](https://github.com/a-r-j/graphein/pull/305) Fixes data types of geometric feature vectors: `object` -> `float`.
 * [Bugfix] - [#301](https://github.com/a-r-j/graphein/pull/301) Fixes the conversion of undirected NetworkX graph to directed PyG data.
+* [Bugfix] - [#334](https://github.com/a-r-j/graphein/pull/334) Fixes the corner case of the NetworkX -> PyG conversion when input graph has no edges.
+
+https://github.com/a-r-j/graphein/pull/334
 
 #### Bugfixes
 * Adds missing `stage` parameter to `graphein.ml.datasets.foldcomp_data.FoldCompDataModule.setup()`. [#310](https://github.com/a-r-j/graphein/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Fixes `add_sequence_neighbour_vector` to have a zero vector when no neighbor is feasible. Extend to handle insertion codes ([#336](https://github.com/a-r-j/graphein/pull/336)).
+
 ### 1.7.3 - 30/08/2023
 
 * Fixes edge case in FoldComp database download if target directory has same name as database ([#339](https://github.com/a-r-j/graphein/pull/339))

--- a/graphein/ml/conversion.py
+++ b/graphein/ml/conversion.py
@@ -289,7 +289,8 @@ class GraphFormatConvertor:
                     data[key].append(value)
 
         # Add edge features
-        edge_feature_names = list(G.edges(data=True))[0][2].keys()
+        edge_list = list(G.edges(data=True))
+        edge_feature_names = edge_list[0][2].keys() if edge_list else []
         edge_feature_names = list(
             filter(
                 lambda x: x in self.columns and x != "kind", edge_feature_names

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -179,10 +179,12 @@ def add_sequence_neighbour_vector(
                 )
                 continue
             # Asserts residues are on the same chain
+            # TODO It seems redunant
             cond_1 = (
                 residue[1]["chain_id"] == chain_residues[i + 1][1]["chain_id"]
             )
             # Asserts residue numbers are adjacent
+            # TODO What about insertions?
             cond_2 = (
                 abs(
                     residue[1]["residue_number"]
@@ -192,6 +194,7 @@ def add_sequence_neighbour_vector(
             )
 
             # If this checks out, we compute the vector
+            # TODO What if not? -> vec is unknown
             if (cond_1) and (cond_2):
                 vec = chain_residues[i + 1][1]["coords"] - residue[1]["coords"]
 

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -178,14 +178,10 @@ def add_sequence_neighbour_vector(
                     [0.0, 0.0, 0.0]
                 )
                 continue
-            # Asserts residues are on the same chain
-            # TODO It seems redunant
-            cond_1 = (
-                residue[1]["chain_id"] == chain_residues[i + 1][1]["chain_id"]
-            )
+
             # Asserts residue numbers are adjacent
             # TODO What about insertions?
-            cond_2 = (
+            cond = (
                 abs(
                     residue[1]["residue_number"]
                     - chain_residues[i + 1][1]["residue_number"]
@@ -195,7 +191,7 @@ def add_sequence_neighbour_vector(
 
             # If this checks out, we compute the vector
             # TODO What if not? -> vec is unknown
-            if (cond_1) and (cond_2):
+            if cond:
                 vec = chain_residues[i + 1][1]["coords"] - residue[1]["coords"]
 
                 if reverse:

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -179,18 +179,36 @@ def add_sequence_neighbour_vector(
                 )
                 continue
 
-            # Asserts residue numbers are adjacent
-            # TODO What about insertions?
-            cond = (
+            # Get insertion codes
+            ins_current = (
+                residue[0].split(':')[3] 
+                if residue[0].count(':') > 2
+                else ''
+            )
+            ins_next = (
+                chain_residues[i + 1][0].split(':')[3]
+                if chain_residues[i + 1][0].count(':') > 2
+                else ''
+            )
+            
+            # Asserts residues are adjacent
+            cond_adjacent = (
                 abs(
                     residue[1]["residue_number"]
                     - chain_residues[i + 1][1]["residue_number"]
                 )
                 == 1
+                or (
+                    not ins_current and ins_next == 'A'
+                )
+                or (
+                    ins_current and ins_next 
+                    and chr(ord(ins_current) + 1) == ins_next
+                )
             )
 
-            # If this checks out, we compute the vector
-            if cond:
+            # If this checks out, we compute the non-zero vector
+            if cond_adjacent:
                 vec = chain_residues[i + 1][1]["coords"] - residue[1]["coords"]
 
                 if reverse:
@@ -198,7 +216,7 @@ def add_sequence_neighbour_vector(
                 if scale:
                     vec = vec / np.linalg.norm(vec)
             else:
-                vec = np.array([0.0, 0.0, 0.0])
+                vec = np.array([0.0, 0.0, 0.0])            
 
             residue[1][f"sequence_neighbour_vector_{suffix}"] = vec
 

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -190,19 +190,25 @@ def add_sequence_neighbour_vector(
                 if chain_residues[i + 1][0].count(':') > 2
                 else ''
             )
+            if not n_to_c:
+                ins_current, ins_next = ins_next, ins_current
+
+            # Get sequence distance
+            dist = abs(
+                residue[1]["residue_number"]
+                - chain_residues[i + 1][1]["residue_number"]
+            )
             
             # Asserts residues are adjacent
             cond_adjacent = (
-                abs(
-                    residue[1]["residue_number"]
-                    - chain_residues[i + 1][1]["residue_number"]
-                )
-                == 1
+                dist == 1
                 or (
-                    not ins_current and ins_next == 'A'
+                    dist == 0
+                    and not ins_current and ins_next == 'A'
                 )
                 or (
-                    ins_current and ins_next 
+                    dist == 0
+                    and ins_current and ins_next 
                     and chr(ord(ins_current) + 1) == ins_next
                 )
             )

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -181,14 +181,12 @@ def add_sequence_neighbour_vector(
 
             # Get insertion codes
             ins_current = (
-                residue[0].split(':')[3] 
-                if residue[0].count(':') > 2
-                else ''
+                residue[0].split(":")[3] if residue[0].count(":") > 2 else ""
             )
             ins_next = (
-                chain_residues[i + 1][0].split(':')[3]
-                if chain_residues[i + 1][0].count(':') > 2
-                else ''
+                chain_residues[i + 1][0].split(":")[3]
+                if chain_residues[i + 1][0].count(":") > 2
+                else ""
             )
             if not n_to_c:
                 ins_current, ins_next = ins_next, ins_current
@@ -198,17 +196,15 @@ def add_sequence_neighbour_vector(
                 residue[1]["residue_number"]
                 - chain_residues[i + 1][1]["residue_number"]
             )
-            
+
             # Asserts residues are adjacent
             cond_adjacent = (
                 dist == 1
+                or (dist == 0 and not ins_current and ins_next == "A")
                 or (
                     dist == 0
-                    and not ins_current and ins_next == 'A'
-                )
-                or (
-                    dist == 0
-                    and ins_current and ins_next 
+                    and ins_current
+                    and ins_next
                     and chr(ord(ins_current) + 1) == ins_next
                 )
             )
@@ -222,7 +218,7 @@ def add_sequence_neighbour_vector(
                 if scale:
                     vec = vec / np.linalg.norm(vec)
             else:
-                vec = np.array([0.0, 0.0, 0.0])            
+                vec = np.array([0.0, 0.0, 0.0])
 
             residue[1][f"sequence_neighbour_vector_{suffix}"] = vec
 

--- a/graphein/protein/features/nodes/geometry.py
+++ b/graphein/protein/features/nodes/geometry.py
@@ -190,7 +190,6 @@ def add_sequence_neighbour_vector(
             )
 
             # If this checks out, we compute the vector
-            # TODO What if not? -> vec is unknown
             if cond:
                 vec = chain_residues[i + 1][1]["coords"] - residue[1]["coords"]
 
@@ -198,6 +197,8 @@ def add_sequence_neighbour_vector(
                     vec = -vec
                 if scale:
                     vec = vec / np.linalg.norm(vec)
+            else:
+                vec = np.array([0.0, 0.0, 0.0])
 
             residue[1][f"sequence_neighbour_vector_{suffix}"] = vec
 

--- a/tests/protein/nodes/features/test_geometry.py
+++ b/tests/protein/nodes/features/test_geometry.py
@@ -8,16 +8,16 @@
 import operator
 from functools import partial
 
-import pytest
 import numpy as np
+import pytest
 from loguru import logger
 
 from graphein.protein.config import ProteinGraphConfig
 from graphein.protein.features.nodes.geometry import (
     add_beta_carbon_vector,
+    add_sequence_neighbour_vector,
     add_sidechain_vector,
     add_virtual_beta_carbon_vector,
-    add_sequence_neighbour_vector
 )
 from graphein.protein.graphs import construct_graph
 

--- a/tests/protein/nodes/features/test_geometry.py
+++ b/tests/protein/nodes/features/test_geometry.py
@@ -8,6 +8,7 @@
 import operator
 from functools import partial
 
+import pytest
 import numpy as np
 from loguru import logger
 
@@ -16,6 +17,7 @@ from graphein.protein.features.nodes.geometry import (
     add_beta_carbon_vector,
     add_sidechain_vector,
     add_virtual_beta_carbon_vector,
+    add_sequence_neighbour_vector
 )
 from graphein.protein.graphs import construct_graph
 
@@ -195,3 +197,22 @@ def test_add_virtual_beta_carbon_vector():
     g = construct_graph(config=config, pdb_code="7w9w")
     for n, d in g.nodes(data=True):
         assert d["virtual_c_beta_vector"].shape == (3,)
+
+
+@pytest.mark.parametrize("n_to_c", [True, False])
+def test_add_sequence_neighbour_vector(n_to_c):
+    config = ProteinGraphConfig(edge_construction_functions=[])
+    g = construct_graph(pdb_code="1igt", config=config)
+    add_sequence_neighbour_vector(g, n_to_c=n_to_c)
+
+    key = "sequence_neighbour_vector_" + ("n_to_c" if n_to_c else "c_to_n")
+    for n, d in g.nodes(data=True):
+        # Check that the node has the correct attributes
+        assert key in d.keys()
+        # Check the vector is of the correct dimensionality
+        assert d[key].shape == (3,)
+
+        # check A insertions have non-zero backward vectors
+        print(n, n_to_c, d[key])
+        if n.endswith(":A") and not n_to_c:
+            assert np.any(np.not_equal(d[key], [0.0, 0.0, 0.0]))


### PR DESCRIPTION
#### Reference Issues/PRs
Hi, @a-r-j 👋! Currently, `add_sequence_neighbour_vector` has two bugs:
- If conditions for adjacency fail, the `vec` from the previous iteration (pair of adjacent residues) is being used. So, the errors propagate silently. I fixed it to put zeros when conditions fail.
- It does not handle insertion codes. Currently, I fixed it by parsing node ids first, but there probably may be a better way to get insertions.

I have also removed a redundant check for chain identity when iterating through the nodes of the same chain, and added a test.

#### What does this implement/fix? Explain your changes

#### What testing did you do to verify the changes in this PR?


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [x] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [x] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
