### PR TITLE
Add support for PyG 2.4+

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,8 @@ jobs:
       #  run: conda env create -n graphein-dev python=${{ matrix.python-version }}
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
+      - name: Install Boost 1.7.3 (for DSSP)
+        run: conda install -c anaconda libboost=1.73.0
       - name: Install DSSP
         run: conda install dssp -c salilab
       - name: Install mmseqs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
       - name: Install DSSP
-        run: sudo apt-get install dssp=3.0.0
+        run: conda install dssp -c salilab
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
         torch: [1.13.0, 2.0.0, 2.1.0]
         #include:
         #  - torch: 1.6.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,8 +60,8 @@ jobs:
       #  run: conda env create -n graphein-dev python=${{ matrix.python-version }}
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
-      - name: Install DSSP
-        run: sudo apt-get install dssp
+      - name: Install DSSP   
+        run: conda install dssp -c salilab
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
       - name: Install DSSP
-	run: sudo apt install dssp
+        run: sudo apt-get install dssp
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
       - name: Install DSSP
-        run: sudo apt-get install dssp
+        run: sudo apt-get install dssp=3.0.0
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
       - name: Install DSSP
-        run: conda install -c salilab dssp
+	run: sudo apt install dssp
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
       - name: Install DSSP
-        run: conda install dssp -c salilab
+        run: sudo apt-get install dssp
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2
       - name: Install PyTorch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
       #  run: conda env create -n graphein-dev python=${{ matrix.python-version }}
       #- name: Activate Conda Environment
       #  run: source activate graphein-dev
-      - name: Install DSSP   
+      - name: Install DSSP
         run: conda install dssp -c salilab
       - name: Install mmseqs
         run: mamba install -c conda-forge -c bioconda mmseqs2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
-        torch: [1.12.0, 1.13.0, 2.0.0]
+        python-version: [3.8, 3.9, 3.10]
+        torch: [1.13.0, 2.0.0, 2.1.0]
         #include:
         #  - torch: 1.6.0
         #    torchvision: 0.7.0

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -4,6 +4,7 @@ biopython
 bioservices>=1.10.0
 deepdiff
 loguru
+looseversion
 matplotlib>=3.4.3
 multipledispatch
 networkx

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -1,6 +1,6 @@
 pandas<2.0.0
 biopandas>=0.5.0.dev0
-biopython<=1.79
+biopython
 bioservices>=1.10.0
 deepdiff
 loguru

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -1,6 +1,6 @@
 pandas<2.0.0
 biopandas>=0.5.0.dev0
-biopython<=1.80
+biopython<=1.79
 bioservices>=1.10.0
 deepdiff
 loguru

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -1,6 +1,6 @@
 pandas<2.0.0
 biopandas>=0.5.0.dev0
-biopython
+biopython<=1.80
 bioservices>=1.10.0
 deepdiff
 loguru

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.4 - 24/10/2023
+
+* Adds support for PyG 2.4+ ([#350](https://www.github.com/a-r-j/graphein/pull/339))
+
 ### 1.7.3 - 30/08/2023
 
 * Fixes edge case in FoldComp database download if target directory has same name as database ([#339](https://github.com/a-r-j/graphein/pull/339))

--- a/graphein/protein/tensor/data.py
+++ b/graphein/protein/tensor/data.py
@@ -11,10 +11,12 @@ from functools import partial
 # Code Repository: https://github.com/a-r-j/graphein
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+import looseversion
 import pandas as pd
 import plotly.graph_objects as go
 import torch
 import torch.nn.functional as F
+import torch_geometric
 from biopandas.pdb import PandasPdb
 from loguru import logger as log
 from torch_geometric.data import Batch, Data
@@ -63,6 +65,8 @@ from .types import (
     PositionTensor,
     TorsionTensor,
 )
+
+PYG_VERSION = looseversion.LooseVersion(torch_geometric.__version__)
 
 
 class Protein(Data):
@@ -249,7 +253,12 @@ class Protein(Data):
         :return: ``Protein`` object containing the same keys and values
         :rtype: Protein
         """
-        keys = data.keys
+        keys = (
+            data.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else data.keys
+        )
+
         for key in keys:
             setattr(self, key, getattr(data, key))
         return self
@@ -271,7 +280,12 @@ class Protein(Data):
         :rtype: Data
         """
         data = Data()
-        for i in self.keys:
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
+        for i in keys:
             setattr(data, i, getattr(self, i))
         return data
 
@@ -732,7 +746,13 @@ class Protein(Data):
 
     def __eq__(self, __o: object) -> bool:
         # sourcery skip: merge-duplicate-blocks, merge-else-if-into-elif
-        for i in self.keys:
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
+
+        for i in keys:
             attr_self = getattr(self, i)
             attr_other = getattr(__o, i)
 
@@ -760,9 +780,15 @@ class Protein(Data):
         return plot_distance_matrix(x)
 
     def plot_dihedrals(self) -> go.Figure:
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
+
         dh = (
             dihedrals(self.coords)
-            if "dihedrals" not in self.keys
+            if "dihedrals" not in keys
             else self.dihedrals
         )
         return plot_dihedrals(dh)
@@ -833,7 +859,12 @@ class ProteinBatch(Batch):
     def from_batch(
         self, batch: Batch, fill_value: float = 1e-5
     ) -> "ProteinBatch":
-        for key in batch.keys:
+        keys = (
+            batch.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else batch.keys
+        )
+        for key in keys:
             setattr(self, key, getattr(batch, key))
 
         if hasattr(batch, "_slice_dict"):
@@ -930,7 +961,11 @@ class ProteinBatch(Batch):
     def to_batch(self) -> Batch:
         """Returns the ProteinBatch as a torch_geometric.data.Batch object."""
         batch = Batch()
-        keys = self.keys
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
         for key in keys:
             setattr(batch, key, getattr(self, key))
         return batch
@@ -1190,8 +1225,12 @@ class ProteinBatch(Batch):
         proteins = [Protein() for _ in range(self.num_graphs)]
 
         # Iterate over attributes
-        for k in self.keys:
-            print(k)
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
+        for k in keys:
             # Get attribute
             attr = getattr(self, k)
             # Skip ptr
@@ -1218,7 +1257,12 @@ class ProteinBatch(Batch):
 
     def __eq__(self, __o: object) -> bool:
         # sourcery skip: merge-duplicate-blocks, merge-else-if-into-elif
-        for i in self.keys:
+        keys = (
+            self.keys()
+            if PYG_VERSION >= looseversion.LooseVersion("2.4.0")
+            else self.keys
+        )
+        for i in keys:
             attr_self = getattr(self, i)
             attr_other = getattr(__o, i)
 

--- a/tests/protein/test_graphs.py
+++ b/tests/protein/test_graphs.py
@@ -129,7 +129,7 @@ def test_construct_graph_with_dssp():
     dssp_prot_config = ProteinGraphConfig(**dssp_config_functions)
 
     g_pdb = construct_graph(
-        config=dssp_prot_config, pdb_code="6YC3"
+        config=dssp_prot_config, pdb_code="6yc3"
     )  # should download 6yc3.pdb to pdb_dir
 
     assert g_pdb.graph["pdb_code"] == "6YC3"

--- a/tests/protein/test_graphs.py
+++ b/tests/protein/test_graphs.py
@@ -132,7 +132,7 @@ def test_construct_graph_with_dssp():
         config=dssp_prot_config, pdb_code="6yc3"
     )  # should download 6yc3.pdb to pdb_dir
 
-    assert g_pdb.graph["pdb_code"] == "6YC3"
+    assert g_pdb.graph["pdb_code"] == "6yc3"
     assert g_pdb.graph["path"] is None
     assert g_pdb.graph["name"] == g_pdb.graph["pdb_code"]
     assert len(g_pdb.graph["dssp_df"]) == 1365

--- a/tests/protein/test_graphs.py
+++ b/tests/protein/test_graphs.py
@@ -106,7 +106,7 @@ def test_construct_graph():
 def test_construct_graph_with_dssp():
     """Makes sure protein graphs can be constructed with dssp
 
-    Uses uses both a pdb code (6REW) and a local pdb file to do so.
+    Uses uses both a pdb code (6YC3) and a local pdb file to do so.
     """
     dssp_config_functions = {
         "edge_construction_functions": [
@@ -129,10 +129,10 @@ def test_construct_graph_with_dssp():
     dssp_prot_config = ProteinGraphConfig(**dssp_config_functions)
 
     g_pdb = construct_graph(
-        config=dssp_prot_config, pdb_code="6rew"
-    )  # should download 6rew.pdb to pdb_dir
+        config=dssp_prot_config, pdb_code="6YC3"
+    )  # should download 6yc3.pdb to pdb_dir
 
-    assert g_pdb.graph["pdb_code"] == "6rew"
+    assert g_pdb.graph["pdb_code"] == "6YC3"
     assert g_pdb.graph["path"] is None
     assert g_pdb.graph["name"] == g_pdb.graph["pdb_code"]
     assert len(g_pdb.graph["dssp_df"]) == 1365


### PR DESCRIPTION
#### Reference Issues/PRs


#### What does this implement/fix? Explain your changes
2.4 introduced breaking changes to `Data.keys` and `Batch.keys`, replacing the attribute with a method (`Data.keys()`). This PR adds `looseversion` to select the keys based on the syntax allowed by old and new PyG versions.


#### What testing did you do to verify the changes in this PR?


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
