### PR TITLE
Handle edge case of computing chi angles for PYL #356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.6 - UNRELEASED
+
+* Fixes bug in sidechain torsion angle computation for structures containing `PYL`/other non-standard amino acids ([#357](https://github.com/a-r-j/graphein/pull/357)). Fixes [#356](https://github.com/a-r-j/graphein/issues/356).
+
 ### 1.7.4 - 26/10/2023
 
 * Adds support for PyG 2.4+ ([#350](https://www.github.com/a-r-j/graphein/pull/339))

--- a/graphein/protein/tensor/angles.py
+++ b/graphein/protein/tensor/angles.py
@@ -77,8 +77,14 @@ def _extract_torsion_coords(
     for i, res in enumerate(res_types):
         res_coords = []
 
-        angle_groups = CHI_ANGLES_ATOMS[res]
-        if not selenium and res == "SEC":
+        try:
+            angle_groups = CHI_ANGLES_ATOMS[res]
+        except KeyError:
+            log.warning(
+                f"Can't determine chi angle groups for non-standard residue: {res}. These will be set to 0"
+            )
+            angle_groups = []
+        if (not selenium and res == "SEC") or res == "PYL":
             angle_groups = []
 
         for angle_coord_set in angle_groups:

--- a/tests/protein/tensor/test_angles.py
+++ b/tests/protein/tensor/test_angles.py
@@ -134,5 +134,5 @@ def test_pyl_torsion_angle():
     sc_angles = sidechain_torsion(p.coords, p.residues)
 
     torch.testing.assert_close(
-        torch.zeros_like(sc_angles[pyl_index]), sc_angles[pyl_index], rtol=1e-5
+        torch.zeros_like(sc_angles[pyl_index]), sc_angles[pyl_index], rtol=1e-5, atol=1e-5
     )

--- a/tests/protein/tensor/test_angles.py
+++ b/tests/protein/tensor/test_angles.py
@@ -9,9 +9,11 @@ from graphein.protein.tensor.angles import (
     angle_to_unit_circle,
     dihedrals_to_rad,
     get_backbone_bond_angles,
+    sidechain_torsion,
     to_ang,
     torsion_to_rad,
 )
+from graphein.protein.tensor.io import protein_to_pyg
 
 try:
     import torch
@@ -122,3 +124,15 @@ def test_dihedrals_to_rad():
 
     delta = ((delta + 2 * np.pi) / np.pi) % 2
     np.testing.assert_allclose(delta, torch.zeros_like(delta), atol=1e-5)
+
+
+@pytest.mark.skipif(not TORCH_AVAIL, reason="PyTorch not available")
+def test_pyl_torsion_angle():
+    p = protein_to_pyg(pdb_code="1nth")
+
+    pyl_index = p.residue_id.index("A:PYL:202:")
+    sc_angles = sidechain_torsion(p.coords, p.residue_id)
+
+    torch.testing.assert_close(
+        torch.zeros_like(sc_angles[pyl_index]), sc_angles[pyl_index], rtol=1e-5
+    )

--- a/tests/protein/tensor/test_angles.py
+++ b/tests/protein/tensor/test_angles.py
@@ -134,5 +134,8 @@ def test_pyl_torsion_angle():
     sc_angles = sidechain_torsion(p.coords, p.residues)
 
     torch.testing.assert_close(
-        torch.zeros_like(sc_angles[pyl_index]), sc_angles[pyl_index], rtol=1e-5, atol=1e-5
+        torch.zeros_like(sc_angles[pyl_index]),
+        sc_angles[pyl_index],
+        rtol=1e-5,
+        atol=1e-5,
     )

--- a/tests/protein/tensor/test_angles.py
+++ b/tests/protein/tensor/test_angles.py
@@ -131,7 +131,7 @@ def test_pyl_torsion_angle():
     p = protein_to_pyg(pdb_code="1nth")
 
     pyl_index = p.residue_id.index("A:PYL:202:")
-    sc_angles = sidechain_torsion(p.coords, p.residue_id)
+    sc_angles = sidechain_torsion(p.coords, p.residues)
 
     torch.testing.assert_close(
         torch.zeros_like(sc_angles[pyl_index]), sc_angles[pyl_index], rtol=1e-5


### PR DESCRIPTION
#### Reference Issues/PRs
#356 

#### What does this implement/fix? Explain your changes
Handles `KeyError` exceptions in looking up chi angle groups for non-standard residues. Logs a warning and sets these angles to 0.


#### What testing did you do to verify the changes in this PR?
Added a test to `tests/protein/tensor/test_angles`/


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [x] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [x] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [x] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
