### PR TITLE
eliminate FutureWarning about Pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Bugfixes
 -   Remove hydrogen isotopes as well in `graphein.protein.graphs.deprotonate_structure`. [#337](https://github.com/a-r-j/graphein/pull/337)
 -   Fixes bug in sidechain torsion angle computation for structures containing `PYL`/other non-standard amino acids ([#357](https://github.com/a-r-j/graphein/pull/357)). Fixes [#356](https://github.com/a-r-j/graphein/issues/356).
+- In Pandas 1.2.0 and later, The default value of regex for `Series.str.replace()` will change from `True` to False. So we need use regular expressions explicitly now, to suppress a FutureWarning. By @StevenAZy ([#359](https://www.github.com/a-r-j/graphein/pull/359))
 
 
 ### 1.7.5 - 27/10/2024

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -158,10 +158,10 @@ def label_node_id(
     if insertions:
         df["node_id"] = df["node_id"] + ":" + df["insertion"].apply(str)
         # Replace trailing : for non insertions
-        df["node_id"] = df["node_id"].str.replace(":$", "")
+        df["node_id"] = df["node_id"].str.replace(":$", "", regex=True)
     # Add Alt Loc identifiers
     df["node_id"] = df["node_id"] + ":" + df["alt_loc"].apply(str)
-    df["node_id"] = df["node_id"].str.replace(":$", "")
+    df["node_id"] = df["node_id"].str.replace(":$", "", regex=True)
     df["residue_id"] = df["node_id"]
     if granularity == "atom":
         df["node_id"] = df["node_id"] + ":" + df["atom_name"]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes
In Pandas 1.2.0 and later, The default value of regex for [Series.str.replace()](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.replace.html#pandas.Series.str.replace) will change from True to False. So we need  use regular expressions explicitly now, otherwise a warning`FutureWarning: The default value of regex will change from True to False in a 
future version` will occur.
