### PR TITLE
Fix cluster file loading bug in `pdb_data.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 #### Bugfixes
 * Add support for DSSP >4. Backwards compatibility is still supported. [#355](https://github.com/a-r-j/graphein/pull/355). Fixes [#353](https://github.com/a-r-j/graphein/issues/353).
 * Fixes bug where RSA features are missing from nodes with insertion codes. [#355](https://github.com/a-r-j/graphein/pull/355). Fixes [#354](https://github.com/a-r-j/graphein/issues/353).
-* Fix bug where the `deprotonate` argument is not wired up to `graphein.protein.graphs.construct_graphs`. [#375](https://github.com/a-r-j/graphein/pull/375)
+* Fix bug where the `deprotonate` argument is not wired up to `graphein.protein.graphs.construct_graphs` [#375](https://github.com/a-r-j/graphein/pull/375)
+* Fix cluster file loading bug in `pdb_data.py` [#396](https://github.com/a-r-j/graphein/pull/396)
 
 #### Misc
 * bumped logging level down from `INFO` to `DEBUG` at several places to reduced output length [#391](https://github.com/a-r-j/graphein/pull/391)

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -1397,7 +1397,7 @@ class PDBManager:
 
         # Read FASTA
         df = self.from_fasta(
-            ids="chain", filename=str(self.root_dir / cluster_fname)
+            ids="chain", filename=str(cluster_fname)
         )
         if update:
             self.df = df

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -1396,9 +1396,7 @@ class PDBManager:
             )
 
         # Read FASTA
-        df = self.from_fasta(
-            ids="chain", filename=str(cluster_fname)
-        )
+        df = self.from_fasta(ids="chain", filename=str(cluster_fname))
         if update:
             self.df = df
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a cluster file loading bug in `pdb_data.py`,

#### What does this implement/fix? Explain your changes

The `PDBManager`'s `from_fasta()` function already prefixes its input `filename` argument with `self.root_dir /`, so one needs to remove this prefix in functions that call `from_fasta()` (to avoid a double prefix that causes a file not found error).

#### What testing did you do to verify the changes in this PR?

I tested this change locally.

#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [x] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
