### PR TITLE
[feat] add uniprot ecnumber and cath label options to pdb manager

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
           channels: "conda-forge, salilab, pytorch, pyg"
           python-version: ${{ matrix.python-version }}
           use-mamba: true
+      - name: Install setuptools
+        run: pip install setuptools==69.5.1
       - name: Install Boost 1.7.3 (for DSSP)
         run: conda install -c anaconda libboost=1.73.0
       - name: Install DSSP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix cluster file loading bug in `pdb_data.py` [#396](https://github.com/a-r-j/graphein/pull/396)
 
 #### Misc
+* add metadata options for uniprot, ecnumber and CATH code to pdb manager [#398](https://github.com/a-r-j/graphein/pull/398)
 * bumped logging level down from `INFO` to `DEBUG` at several places to reduced output length [#391](https://github.com/a-r-j/graphein/pull/391)
 * exposed `fill_value` and `bfactor` option to `protein_to_pyg` function. [#385](https://github.com/a-r-j/graphein/pull/385) and [#388](https://github.com/a-r-j/graphein/pull/388)
 * Updated Foldcomp datasets with improved setup function and updated database choices such as ESMAtlas. [#382](https://github.com/a-r-j/graphein/pull/382)

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -553,7 +553,7 @@ class PDBManager:
         df.dropna(subset=["id"], inplace=True)
 
         df.id = df.id.str.lower()
-        df.date = pd.to_datetime(df.date)
+        df.date = pd.to_datetime(df.date, format = "%m/%d/%y")
         return pd.Series(df["date"].values, index=df["id"]).to_dict()
 
     def _parse_experiment_type(self) -> Dict[str, str]:
@@ -704,7 +704,7 @@ class PDBManager:
         df["deposition_date"] = df.pdb.map(self._parse_entries())
         df["experiment_type"] = df.pdb.map(self._parse_experiment_type())
         df["pdb_file_available"] = df.pdb.map(self._parse_pdb_availability())
-        df.pdb_file_available.fillna(True, inplace=True)
+        df["pdb_file_available"] = df["pdb_file_available"].fillna(True)
         if labels:
             if "uniprot_id" in labels:
                 df["uniprot_id"] = df.id.map(self._parse_uniprot_id())
@@ -1771,8 +1771,8 @@ class PDBManager:
 
     def download_pdbs(
         self,
-        out_dir=".",
-        format="pdb",
+        out_dir: str = ".",
+        format: str = "pdb",
         splits: Optional[List[str]] = None,
         overwrite: bool = False,
         max_workers: int = 8,

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, Literal
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -36,7 +36,9 @@ class PDBManager:
         split_ratios: Optional[List[float]] = None,
         split_time_frames: Optional[List[np.datetime64]] = None,
         assign_leftover_rows_to_split_n: int = 0,
-        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
+        labels: Optional[
+            List[Literal["uniprot_id", "cath_code", "ec_number"]]
+        ] = None,
     ):
         """Instantiate a selection of experimental PDB structures.
 
@@ -93,8 +95,6 @@ class PDBManager:
 
         self.pdb_chain_ec_number_url = "https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_enzyme.tsv.gz"
 
-
-
         self.pdb_dir = self.root_dir / "pdb"
         if not os.path.exists(self.pdb_dir):
             os.makedirs(self.pdb_dir)
@@ -111,9 +111,13 @@ class PDBManager:
             self.pdb_deposition_date_url
         ).name
         self.pdb_availability_filename = Path(self.pdb_availability_url).name
-        self.pdb_chain_cath_uniprot_filename = Path(self.pdb_chain_cath_uniprot_url).name
+        self.pdb_chain_cath_uniprot_filename = Path(
+            self.pdb_chain_cath_uniprot_url
+        ).name
         self.cath_id_cath_code_filename = Path(self.cath_id_cath_code_url).name
-        self.pdb_chain_ec_number_filename = Path(self.pdb_chain_ec_number_url).name
+        self.pdb_chain_ec_number_filename = Path(
+            self.pdb_chain_ec_number_url
+        ).name
 
         self.list_columns = ["ligands"]
 
@@ -428,16 +432,20 @@ class PDBManager:
             log.info("Downloading PDB availability map...")
             wget.download(self.pdb_availability_url, out=str(self.root_dir))
             log.debug("Downloaded PDB availability map")
-    
+
     def _download_pdb_chain_cath_uniprot_map(self):
         """Download mapping from PDB chain to uniprot accession and CATH ID from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_cath_uniprot.tsv.gz
         """
-        if not os.path.exists(self.root_dir / self.pdb_chain_cath_uniprot_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename
+        ):
             log.info("Downloading Uniprot CATH map...")
-            wget.download(self.pdb_chain_cath_uniprot_url, out=str(self.root_dir))
+            wget.download(
+                self.pdb_chain_cath_uniprot_url, out=str(self.root_dir)
+            )
             log.debug("Downloaded Uniprot CATH map")
-    
+
     def _download_cath_id_cath_code_map(self):
         """Download mapping from CATH IDs to CATH code from
         http://download.cathdb.info/cath/releases/daily-release/newest/cath-b-newest-all.gz
@@ -451,7 +459,9 @@ class PDBManager:
         """Download mapping from PDB chains to EC number from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_enzyme.tsv.gz
         """
-        if not os.path.exists(self.root_dir / self.pdb_chain_ec_number_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_chain_ec_number_filename
+        ):
             log.info("Downloading EC number map...")
             wget.download(self.pdb_chain_ec_number_url, out=str(self.root_dir))
             log.debug("Downloaded EC number map")
@@ -553,7 +563,7 @@ class PDBManager:
         df.dropna(subset=["id"], inplace=True)
 
         df.id = df.id.str.lower()
-        df.date = pd.to_datetime(df.date, format = "%m/%d/%y")
+        df.date = pd.to_datetime(df.date, format="%m/%d/%y")
         return pd.Series(df["date"].values, index=df["id"]).to_dict()
 
     def _parse_experiment_type(self) -> Dict[str, str]:
@@ -589,16 +599,18 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         uniprot_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, 'rt') as f:
+        with gzip.open(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
+        ) as f:
             for line in f:
                 try:
-                    pdb, chain, uniprot_id, cath_id = line.strip().split('\t')
+                    pdb, chain, uniprot_id, cath_id = line.strip().split("\t")
                     key = f"{pdb}_{chain}"
                     uniprot_mapping[key] = uniprot_id
                 except ValueError:
                     continue
         return uniprot_mapping
-    
+
     def _parse_cath_id(self) -> Dict[str, str]:
         """Parse the CATH ID for all PDB chains.
 
@@ -607,17 +619,19 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         cath_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, 'rt') as f:
-            next(f) # Skip header line
+        with gzip.open(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
+        ) as f:
+            next(f)  # Skip header line
             for line in f:
                 try:
-                    pdb, chain, uniprot_id, cath_id = line.strip().split('\t')
+                    pdb, chain, uniprot_id, cath_id = line.strip().split("\t")
                     key = f"{pdb}_{chain}"
                     cath_mapping[key] = cath_id
                 except ValueError:
                     continue
         return cath_mapping
-    
+
     def _parse_cath_code(self) -> Dict[str, str]:
         """Parse the CATH code for all CATH IDs.
 
@@ -626,18 +640,22 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         cath_mapping = {}
-        with gzip.open(self.root_dir / self.cath_id_cath_code_filename, 'rt') as f:
+        with gzip.open(
+            self.root_dir / self.cath_id_cath_code_filename, "rt"
+        ) as f:
             print(f)
             for line in f:
                 print(line)
                 try:
-                    cath_id, cath_version, cath_code, cath_segment = line.strip().split()
+                    cath_id, cath_version, cath_code, cath_segment = (
+                        line.strip().split()
+                    )
                     cath_mapping[cath_id] = cath_code
                     print(cath_id, cath_code)
                 except ValueError:
                     continue
         return cath_mapping
-    
+
     def _parse_ec_number(self) -> Dict[str, str]:
         """Parse the CATH ID for all PDB chains and adds None when no EC number is present.
 
@@ -646,19 +664,28 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         ec_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_ec_number_filename, 'rt') as f:
-            next(f) # Skip header line
+        with gzip.open(
+            self.root_dir / self.pdb_chain_ec_number_filename, "rt"
+        ) as f:
+            next(f)  # Skip header line
             for line in f:
                 try:
-                    pdb, chain, uniprot_id, ec_number = line.strip().split('\t')
+                    pdb, chain, uniprot_id, ec_number = line.strip().split(
+                        "\t"
+                    )
                     key = f"{pdb}_{chain}"
-                    ec_number = None if ec_number == '?' else ec_number
+                    ec_number = None if ec_number == "?" else ec_number
                     ec_mapping[key] = ec_number
                 except ValueError:
                     continue
         return ec_mapping
 
-    def parse(self, labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None) -> pd.DataFrame:
+    def parse(
+        self,
+        labels: Optional[
+            List[Literal["uniprot_id", "cath_code", "ec_number"]]
+        ] = None,
+    ) -> pd.DataFrame:
         """Parse all PDB sequence records.
 
         :param labels: A list of names corresponding to metadata labels that should be included in PDB manager dataframe,
@@ -1308,15 +1335,14 @@ class PDBManager:
         :rtype: pd.DataFrame
         """
         splits_df = self.get_splits(splits)
-        df = splits_df.dropna(subset=['uniprot_id'])
+        df = splits_df.dropna(subset=["uniprot_id"])
 
         if select_ids:
-            df = df[df['uniprot_id'].isin(select_ids)]
+            df = df[df["uniprot_id"].isin(select_ids)]
 
         if update:
             self.df = df
         return df
-
 
     def has_cath_code(
         self,
@@ -1342,11 +1368,10 @@ class PDBManager:
         :rtype: pd.DataFrame
         """
         splits_df = self.get_splits(splits)
-        df = splits_df.dropna(subset=['cath_code'])
+        df = splits_df.dropna(subset=["cath_code"])
 
         if select_ids:
-            df = df[df['cath_code'].isin(select_ids)]
-
+            df = df[df["cath_code"].isin(select_ids)]
 
         if update:
             self.df = df
@@ -1376,10 +1401,10 @@ class PDBManager:
         :rtype: pd.DataFrame
         """
         splits_df = self.get_splits(splits)
-        df = splits_df.dropna(subset=['ec_number'])
+        df = splits_df.dropna(subset=["ec_number"])
 
         if select_ids:
-            df = df[df['ec_number'].isin(select_ids)]
+            df = df[df["ec_number"].isin(select_ids)]
 
         if update:
             self.df = df

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, Literal
 
 import numpy as np
 import pandas as pd
@@ -36,7 +36,7 @@ class PDBManager:
         split_ratios: Optional[List[float]] = None,
         split_time_frames: Optional[List[np.datetime64]] = None,
         assign_leftover_rows_to_split_n: int = 0,
-        labels: Optional[List[str]] = None,
+        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
     ):
         """Instantiate a selection of experimental PDB structures.
 
@@ -61,7 +61,7 @@ class PDBManager:
         :type assign_leftover_rows_to_split_n: int, optional
         :param labels: A list of names corresponding to metadata labels that should be included in PDB manager dataframe,
             defaults to ``None``.
-        :type labels: Optional[List[str]], optional
+        :type labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]], optional
         """
         # Arguments
         self.root_dir = Path(root_dir)
@@ -658,7 +658,7 @@ class PDBManager:
                     continue
         return ec_mapping
 
-    def parse(self, labels: List[str]) -> pd.DataFrame:
+    def parse(self, labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None) -> pd.DataFrame:
         """Parse all PDB sequence records.
 
         :param labels: A list of names corresponding to metadata labels that should be included in PDB manager dataframe,
@@ -1286,12 +1286,17 @@ class PDBManager:
 
     def has_uniprot_id(
         self,
+        select_ids: Optional[List[str]] = None,
         splits: Optional[List[str]] = None,
         update: bool = False,
     ) -> pd.DataFrame:
         """
         Select entries that have a uniprot ID.
 
+        :param select_ids: If present, filter for only these IDs. If not present, filter for entries
+            that have any uniprot ID.
+            defaults to ``None``.
+        :type select_ids: Optional[List[str]], optional
         :param splits: Names of splits for which to perform the operation,
             defaults to ``None``.
         :type splits: Optional[List[str]], optional
@@ -1305,6 +1310,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         df = splits_df.dropna(subset=['uniprot_id'])
 
+        if select_ids:
+            df = df[df['uniprot_id'].isin(select_ids)]
+
         if update:
             self.df = df
         return df
@@ -1312,12 +1320,17 @@ class PDBManager:
 
     def has_cath_code(
         self,
+        select_ids: Optional[List[str]] = None,
         splits: Optional[List[str]] = None,
         update: bool = False,
     ) -> pd.DataFrame:
         """
         Select entries that have a cath code.
 
+        :param select_ids: If present, filter for only these CATH codes. If not present, filter for entries
+            that have any cath code.
+            defaults to ``None``.
+        :type select_ids: Optional[List[str]], optional
         :param splits: Names of splits for which to perform the operation,
             defaults to ``None``.
         :type splits: Optional[List[str]], optional
@@ -1331,18 +1344,27 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         df = splits_df.dropna(subset=['cath_code'])
 
+        if select_ids:
+            df = df[df['cath_code'].isin(select_ids)]
+
+
         if update:
             self.df = df
         return df
 
     def has_ec_number(
         self,
+        select_ids: Optional[List[str]] = None,
         splits: Optional[List[str]] = None,
         update: bool = False,
     ) -> pd.DataFrame:
         """
         Select entries that have an EC number.
 
+        :param select_ids: If present, filter for only these ec_numbers. If not present, filter for entries
+            that have any EC number
+            defaults to ``None``.
+        :type select_ids: Optional[List[str]], optional
         :param splits: Names of splits for which to perform the operation,
             defaults to ``None``.
         :type splits: Optional[List[str]], optional
@@ -1355,6 +1377,9 @@ class PDBManager:
         """
         splits_df = self.get_splits(splits)
         df = splits_df.dropna(subset=['ec_number'])
+
+        if select_ids:
+            df = df[df['ec_number'].isin(select_ids)]
 
         if update:
             self.df = df

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -349,7 +349,7 @@ def protein_df_to_tensor(
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(get_residue_id(df, unique=False))[0]
+    residue_indices = pd.factorize(pd.Series(get_residue_id(df, unique=False)))[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -349,7 +349,9 @@ def protein_df_to_tensor(
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(pd.Series(get_residue_id(df, unique=False)))[0]
+    residue_indices = pd.factorize(
+        pd.Series(get_residue_id(df, unique=False))
+    )[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -108,7 +108,7 @@ def download_pdb_multiprocessing(
     :type pdb_codes: List[str]
     :param out_dir: Path to directory to download PDB structures to.
     :type out_dir: Union[str, Path]
-    :param format: Filetype to download. ``pdb`` or ``mmtf``.
+    :param format: Filetype to download. ``pdb``, ``mmtf``, ``mmcif`` or ``bcif``.
     :type format: str
     :param overwrite: Whether to overwrite existing files, defaults to
         ``False``.
@@ -162,7 +162,7 @@ def download_pdb(
     :param out_dir: Path to directory to download PDB structure to. If ``None``,
         will download to a temporary directory.
     :type out_dir: Optional[Union[str, Path]]
-    :param format: Filetype to download. ``pdb`` or ``mmtf``.
+    :param format: Filetype to download. ``pdb``, ``mmtf``, ``mmcif`` or ``bcif``.
     :type format: str
     :param check_obsolete: Whether to check for obsolete PDB codes,
         defaults to ``False``. If an obsolete PDB code is found, the updated PDB
@@ -183,8 +183,14 @@ def download_pdb(
     elif format == "mmtf":
         BASE_URL = "https://mmtf.rcsb.org/v1.0/full/"
         extension = ".mmtf.gz"
+    elif format == "mmcif":
+        BASE_URL = "https://files.rcsb.org/download/"
+        extension = ".cif.gz"
+    elif format == "bcif":
+        BASE_URL = "https://models.rcsb.org/"
+        extension = ".bcif.gz"
     else:
-        raise ValueError(f"Invalid format: {format}. Must be 'pdb' or 'mmtf'.")
+        raise ValueError(f"Invalid format: {format}. Must be 'pdb', 'mmtf', 'mmcif' or 'bcif'.")
 
     # Make output directory if it doesn't exist or set it to tempdir if None
     if out_dir is not None:

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -190,7 +190,9 @@ def download_pdb(
         BASE_URL = "https://models.rcsb.org/"
         extension = ".bcif.gz"
     else:
-        raise ValueError(f"Invalid format: {format}. Must be 'pdb', 'mmtf', 'mmcif' or 'bcif'.")
+        raise ValueError(
+            f"Invalid format: {format}. Must be 'pdb', 'mmtf', 'mmcif' or 'bcif'."
+        )
 
     # Make output directory if it doesn't exist or set it to tempdir if None
     if out_dir is not None:

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
     python_requires=">=3.7",
-    setup_requires=['setuptools==69.5.1'],
+    setup_requires=["setuptools==69.5.1"],
     license="MIT",
     platforms="any",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
     python_requires=">=3.7",
+    setup_requires=['setuptools==69.5.1'],
     license="MIT",
     platforms="any",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,6 @@ setup(
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
     python_requires=">=3.7",
-    setup_requires=["setuptools==69.5.1"],
     license="MIT",
     platforms="any",
     classifiers=[


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

We add the possibility to add metadata as part of the pdb manager, for example ec number, uniprot id or cath code and also filter by these.

Also adds option to download pdb data in mmcif and bcif format.

Also change a few pandas commands to satisfy deprecation warnings.

#### What testing did you do to verify the changes in this PR?

The change is made in a backward-compatible way; all old options and tests still run, but one can pass in new labels to enable that new option.


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [x] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
