### PR TITLE
Feat/coord mask and logging change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix cluster file loading bug in `pdb_data.py` [#396](https://github.com/a-r-j/graphein/pull/396)
 
 #### Misc
+* set logging to false by default and added options to get atom37 masks in addition to positions [#401](https://github.com/a-r-j/graphein/pull/401)
 * add metadata options for uniprot, ecnumber and CATH code to pdb manager [#398](https://github.com/a-r-j/graphein/pull/398)
 * bumped logging level down from `INFO` to `DEBUG` at several places to reduced output length [#391](https://github.com/a-r-j/graphein/pull/391)
 * exposed `fill_value` and `bfactor` option to `protein_to_pyg` function. [#385](https://github.com/a-r-j/graphein/pull/385) and [#388](https://github.com/a-r-j/graphein/pull/388)

--- a/graphein/__init__.py
+++ b/graphein/__init__.py
@@ -21,11 +21,12 @@ logger.configure(
     ]
 )
 
+logger.disable("graphein")
 
-def verbose(enabled: bool = False):
+def verbose(enabled: bool = True):
     """Enable/Disable logging.
 
-    :param enabled: Whether or not to enable logging, defaults to ``False``.
+    :param enabled: Whether or not to enable logging, defaults to ``True``.
     :type enabled: bool, optional
     """
     if not enabled:

--- a/graphein/__init__.py
+++ b/graphein/__init__.py
@@ -23,6 +23,7 @@ logger.configure(
 
 logger.disable("graphein")
 
+
 def verbose(enabled: bool = True):
     """Enable/Disable logging.
 

--- a/graphein/__init__.py
+++ b/graphein/__init__.py
@@ -24,10 +24,10 @@ logger.configure(
 logger.disable("graphein")
 
 
-def verbose(enabled: bool = True):
+def verbose(enabled: bool = False):
     """Enable/Disable logging.
 
-    :param enabled: Whether or not to enable logging, defaults to ``True``.
+    :param enabled: Whether or not to enable logging, defaults to ``False``.
     :type enabled: bool, optional
     """
     if not enabled:

--- a/graphein/protein/graphs.py
+++ b/graphein/protein/graphs.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import networkx as nx
 import numpy as np
 import pandas as pd
+from biopandas.mmcif import PandasMmcif
 from biopandas.mmtf import PandasMmtf
 from biopandas.pdb import PandasPdb
 from loguru import logger as log
@@ -111,9 +112,11 @@ def read_pdb_to_dataframe(
             atomic_df = PandasPdb().read_pdb(path)
         elif path.endswith(".mmtf") or path.endswith(".mmtf.gz"):
             atomic_df = PandasMmtf().read_mmtf(path)
+        elif path.endswith(".cif") or path.endswith(".cif.gz"):
+            atomic_df = PandasMmcif().read_mmcif(path)
         else:
             raise ValueError(
-                f"File {path} must be either .pdb(.gz), .mmtf(.gz) or .ent, not {path.split('.')[-1]}"
+                f"File {path} must be either .pdb(.gz), .mmtf(.gz), .cif(.gz) or .ent, not {path.split('.')[-1]}"
             )
     elif uniprot_id is not None:
         atomic_df = PandasPdb().fetch_pdb(
@@ -121,11 +124,11 @@ def read_pdb_to_dataframe(
         )
     else:
         atomic_df = PandasPdb().fetch_pdb(pdb_code)
-
     atomic_df = atomic_df.get_model(model_index)
     if len(atomic_df.df["ATOM"]) == 0:
         raise ValueError(f"No model found for index: {model_index}")
-
+    if type(atomic_df) is PandasMmcif:
+        atomic_df = atomic_df.convert_to_pandas_pdb()
     return pd.concat([atomic_df.df["ATOM"], atomic_df.df["HETATM"]])
 
 

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -49,7 +49,7 @@ except ImportError:
         conda_channel="pyg",
         pip_install=True,
     )
-    log.debug(message)
+    log.warning(message)
 
 try:
     import torch
@@ -60,7 +60,7 @@ except ImportError:
         conda_channel="pytorch",
         pip_install=True,
     )
-    log.debug(message)
+    log.warning(message)
 
 
 def get_protein_length(df: pd.DataFrame, insertions: bool = True) -> int:
@@ -108,8 +108,8 @@ def protein_to_pyg(
     atom_types: List[str] = PROTEIN_ATOMS,
     remove_nonstandard: bool = True,
     store_het: bool = False,
-    store_bfactor: bool = False,
     fill_value_coords: float = 1e-5,
+    return_coord_mask: bool = False,
 ) -> Data:
     """
     Parses a protein (from either: a PDB code, PDB file or a UniProt ID
@@ -160,12 +160,9 @@ def protein_to_pyg(
     :param store_het: Whether or not to store heteroatoms in the ``Data``
         object. Default is ``False``.
     :type store_het: bool
-    :param store_bfactor: Whether or not to store bfactors in the ``Data``
-        object. Default is ``False.
-    :type store_bfactor: bool
-    :param fill_value_coords: Fill value to use for positions in atom37
-        representation that are not filled. Defaults to 1e-5
-    :type fill_value_coords: float
+    :param return_coord_mask: Whether to include the coordinate mask as a feature. Default is
+        ``False``.
+    :type keep_insertions: bool
     :returns: ``Data`` object with attributes: ``x`` (AtomTensor), ``residues``
         (list of 3-letter residue codes), id (ID of protein), residue_id (E.g.
         ``"A:SER:1"``), residue_type (torch.Tensor), ``chains`` (torch.Tensor).
@@ -245,9 +242,6 @@ def protein_to_pyg(
         df["residue_id"] = df.residue_id + ":" + df.insertion
 
     out = Data(
-        coords=protein_df_to_tensor(
-            df, atoms_to_keep=atom_types, fill_value=fill_value_coords
-        ),
         residues=get_sequence(
             df,
             chains=chain_selection,
@@ -259,14 +253,17 @@ def protein_to_pyg(
         residue_type=residue_type_tensor(df),
         chains=protein_df_to_chain_tensor(df),
     )
+    if return_coord_mask:
+        coords,coord_mask=protein_df_to_tensor(
+            df, atoms_to_keep=atom_types, fill_value=fill_value_coords, return_coord_mask=return_coord_mask
+        )
+    else:
+        coords=protein_df_to_tensor(
+            df, atoms_to_keep=atom_types, fill_value=fill_value_coords
+        )
+
     if store_het:
         out.hetatms = [het_coords]
-
-    if store_bfactor:
-        # group by residue_id and average b_factor per residue
-        residue_bfactors = df.groupby("residue_id")["b_factor"].mean()
-        out.bfactor = torch.from_numpy(residue_bfactors.values)
-
     return out
 
 
@@ -330,6 +327,7 @@ def protein_df_to_tensor(
     atoms_to_keep: List[str] = PROTEIN_ATOMS,
     insertions: bool = True,
     fill_value: float = 1e-5,
+    return_coord_mask: bool = False
 ) -> AtomTensor:
     """
     Transforms a DataFrame of a protein structure into a
@@ -344,14 +342,14 @@ def protein_df_to_tensor(
     :type insertions: bool
     :param fill_value: Value to fill missing entries with. Defaults to ``1e-5``.
     :type fill_value: float
-    :returns: ``Length x Num_Atoms (default 37) x 3`` tensor.
+    :param return_coord_mask: Whether to return the coord mask created. Defaults to ``False``.
+    :type insertions: bool
+    :returns: ``Length x Num_Atoms (default 37) x 3`` tensor and, if return_coord_mask==True, also the coord_mask tensor.
     :rtype: graphein.protein.tensor.types.AtomTensor
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(
-        pd.Series(get_residue_id(df, unique=False))
-    )[0]
+    residue_indices = pd.factorize(get_residue_id(df, unique=False))[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (
@@ -360,7 +358,13 @@ def protein_df_to_tensor(
     positions[residue_indices, atom_indices] = torch.tensor(
         df[["x_coord", "y_coord", "z_coord"]].values
     ).float()
-    return positions
+
+    if return_coord_mask:
+        coord_mask = torch.zeros((num_residues, len(atoms_to_keep)))
+        coord_mask[residue_indices, atom_indices] = 1
+        return coords, coord_mask
+    else:
+        return positions
 
 
 def to_dataframe(

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -262,11 +262,11 @@ def protein_to_pyg(
     )
     
     if return_coord_mask:
-        out.coords,out.coord_mask=protein_df_to_tensor(
+        out.coords, out.coord_mask = protein_df_to_tensor(
             df, atoms_to_keep=atom_types, fill_value=fill_value_coords, return_coord_mask=return_coord_mask
         )
     else:
-        out.coords=protein_df_to_tensor(
+        out.coords = protein_df_to_tensor(
             df, atoms_to_keep=atom_types, fill_value=fill_value_coords
         )
 
@@ -376,7 +376,7 @@ def protein_df_to_tensor(
     if return_coord_mask:
         coord_mask = torch.zeros((num_residues, len(atoms_to_keep)))
         coord_mask[residue_indices, atom_indices] = 1
-        return coords, coord_mask
+        return positions, coord_mask
     else:
         return positions
 

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -352,7 +352,7 @@ def protein_df_to_tensor(
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(np.array(get_residue_id(df, unique=False)))[0]
+    residue_indices = pd.factorize(pd.Series(get_residue_id(df, unique=False)))[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -161,6 +161,9 @@ def protein_to_pyg(
     :param store_het: Whether or not to store heteroatoms in the ``Data``
         object. Default is ``False``.
     :type store_het: bool
+    :param fill_value_coords: Fill value to use for positions in atom37
+        representation that are not filled. Defaults to 1e-5
+    :type fill_value_coords: float
     :param return_coord_mask: Whether to include the coordinate mask as a feature. Default is
         ``False``.
     :type keep_insertions: bool

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -369,7 +369,7 @@ def protein_df_to_tensor(
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(get_residue_id(df, unique=False))[0]
+    residue_indices = pd.factorize(np.array(get_residue_id(df, unique=False)))[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -263,10 +263,13 @@ def protein_to_pyg(
         residue_type=residue_type_tensor(df),
         chains=protein_df_to_chain_tensor(df),
     )
-    
+
     if return_coord_mask:
         out.coords, out.coord_mask = protein_df_to_tensor(
-            df, atoms_to_keep=atom_types, fill_value=fill_value_coords, return_coord_mask=return_coord_mask
+            df,
+            atoms_to_keep=atom_types,
+            fill_value=fill_value_coords,
+            return_coord_mask=return_coord_mask,
         )
     else:
         out.coords = protein_df_to_tensor(
@@ -344,7 +347,7 @@ def protein_df_to_tensor(
     atoms_to_keep: List[str] = PROTEIN_ATOMS,
     insertions: bool = True,
     fill_value: float = 1e-5,
-    return_coord_mask: bool = False
+    return_coord_mask: bool = False,
 ) -> AtomTensor:
     """
     Transforms a DataFrame of a protein structure into a

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -245,9 +245,9 @@ def protein_to_pyg(
         df["residue_id"] = df.residue_id + ":" + df.insertion
 
     out = Data(
-        coords = protein_df_to_tensor(
-            df, 
-            atoms_to_keep=atom_types, 
+        coords=protein_df_to_tensor(
+            df,
+            atoms_to_keep=atom_types,
             fill_value=fill_value_coords,
         ),
         residues=get_sequence(
@@ -352,7 +352,9 @@ def protein_df_to_tensor(
     """
     num_residues = get_protein_length(df, insertions=insertions)
     df = df.loc[df["atom_name"].isin(atoms_to_keep)]
-    residue_indices = pd.factorize(pd.Series(get_residue_id(df, unique=False)))[0]
+    residue_indices = pd.factorize(
+        pd.Series(get_residue_id(df, unique=False))
+    )[0]
     atom_indices = df["atom_name"].map(lambda x: atoms_to_keep.index(x)).values
 
     positions: AtomTensor = (
@@ -361,7 +363,7 @@ def protein_df_to_tensor(
     positions[residue_indices, atom_indices] = torch.tensor(
         df[["x_coord", "y_coord", "z_coord"]].values
     ).float()
-        
+
     return positions
 
 

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -183,7 +183,7 @@ def download_pdb(
     elif format == "mmtf":
         BASE_URL = "https://mmtf.rcsb.org/v1.0/full/"
         extension = ".mmtf.gz"
-    elif format == "mmcif":
+    elif format == "cif":
         BASE_URL = "https://files.rcsb.org/download/"
         extension = ".cif.gz"
     elif format == "bcif":


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes

1. Enables the user to also get a atom37 coordinate mask if needed for their protein (while maintaining backward compatible behaviour)
2. Disables graphein logging by default

#### What testing did you do to verify the changes in this PR?


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
