### PR TITLE
Fix incorrect node lookup in distance-based edge generation Fixes #418

### DIFF
--- a/graphein/protein/edges/distance.py
+++ b/graphein/protein/edges/distance.py
@@ -959,17 +959,24 @@ def add_distance_threshold(
     )
     dist_mat = compute_distmat(pdb_df)
     interacting_nodes = get_interacting_atoms(threshold, distmat=dist_mat)
+
+    index_to_node_id = pdb_df["node_id"].reset_index(drop=True)
     interacting_nodes = list(zip(interacting_nodes[0], interacting_nodes[1]))
 
     log.info(f"Found: {len(interacting_nodes)} distance edges")
     count = 0
     for a1, a2 in interacting_nodes:
-        n1 = G.graph["pdb_df"].loc[a1, "node_id"]
-        n2 = G.graph["pdb_df"].loc[a2, "node_id"]
-        n1_chain = G.graph["pdb_df"].loc[a1, "chain_id"]
-        n2_chain = G.graph["pdb_df"].loc[a2, "chain_id"]
-        n1_position = G.graph["pdb_df"].loc[a1, "residue_number"]
-        n2_position = G.graph["pdb_df"].loc[a2, "residue_number"]
+
+        n1 = index_to_node_id[a1]
+        n2 = index_to_node_id[a2]
+        
+        row1 = G.graph["pdb_df"].set_index("node_id").loc[n1]
+        row2 = G.graph["pdb_df"].set_index("node_id").loc[n2]
+
+        n1_chain = row1["chain_id"]
+        n2_chain = row2["chain_id"]
+        n1_position = row1["residue_number"]
+        n2_position = row2["residue_number"]
 
         condition_1 = n1_chain == n2_chain
         condition_2 = (


### PR DESCRIPTION
Previously, the node indices from the distance matrix were used to access rows in the full PDB DataFrame (`G.graph["pdb_df"]`), assuming their indices aligned. This caused incorrect residue pairings when the filtered DataFrame used to compute distances had a different row order or subset of residues.

This patch introduces an explicit mapping from filtered DataFrame indices back to the original node IDs, ensuring that edges are created between the correct residues in the correct chains.

This resolves issues where edges were created between spatially distant residues or between unrelated chains.

#### Reference Issues/PRs

Fixes #418

#### What does this implement/fix? Explain your changes

Fixes a mismatch between the distance matrix indices and the full PDB DataFrame (G.graph["pdb_df"]) during edge creation.
Ensures that spatial edges are added between correct residue pairs (same chain, correct distance) by mapping filtered indices back to their original node IDs.

#### What testing did you do to verify the changes in this PR?

I manually validated the fix using the Titin protein as a test case. For randomly selected residues (such as residue 0), I inspected their neighbors in ChimeraX and compared them against the neighbors returned by the updated code. All observed interactions were spatially coherent and within the specified threshold of 7Å. I repeated this process for several residues and found no incorrect long-distance interactions, confirming that the fix produces physically valid edges.

#### Pull Request Checklist

- [x] Ran `python -m pytest tests/` and made sure that all unit tests pass
- [x] Confirmed that the bug fix does not affect unrelated modules
- [ ] Added a note about the fix to the `CHANGELOG.md` (optional, only if they require)
- [ ] Added unit test (optional, fix was validated manually)
- [x] Verified that no incorrect edges are created across chains

