### PR TITLE
fix: guard rdkit-dependent constants in atoms.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Bugfixes
 
+* Fix `NameError` in `graphein.molecule.atoms` when rdkit is not installed by guarding rdkit-dependent constants with `_HAS_RDKIT` flag
 * Fix computation of `GetContacts` edges for local renamed structures [#436](https://github.com/a-r-j/graphein/pull/436). Fixes [#435](https://github.com/a-r-j/graphein/issues/435)
 * Hotfix for incorrect dataframe indexing resulting in correct edge addition in `add_distance_threshold` [#419](https://github.com/a-r-j/graphein/pull/419)
 * Fixes unnecessary download for pre-existing structure files retrieved from AlphaFold database in `graphein.ml.ProteinGraphDataset`[#426](https://github.com/a-r-j/graphein/pull/426)

--- a/graphein/molecule/atoms.py
+++ b/graphein/molecule/atoms.py
@@ -21,7 +21,10 @@ from graphein.utils.dependencies import import_message
 
 try:
     import rdkit.Chem as Chem
+
+    _HAS_RDKIT = True
 except (ImportError, ModuleNotFoundError):
+    _HAS_RDKIT = False
     logger.warning(
         import_message(__name__, "rdkit", "rdkit", True, extras=True)
     )
@@ -95,121 +98,130 @@ ALLOWED_DEGREES: List[int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 ALLOWED_VALENCES: List[int] = [0, 1, 2, 3, 4, 5, 6]
 """Vocabulary of allowed atom valences."""
 
-ALLOWED_HYBRIDIZATIONS: List[Chem.rdchem.HybridizationType] = [
-    Chem.rdchem.HybridizationType.SP,
-    Chem.rdchem.HybridizationType.SP2,
-    Chem.rdchem.HybridizationType.SP3,
-    Chem.rdchem.HybridizationType.SP3D,
-    Chem.rdchem.HybridizationType.SP3D2,
-]
-"""Vocabulary of allowed hybridizations."""
-
 ALLOWED_NUM_H: List[int] = [0, 1, 2, 3, 4]
 """Vocabulary of allowed number of Hydrogens."""
 
-ALLOWED_BOND_TYPES: List[Chem.rdchem.BondType] = [
-    Chem.rdchem.BondType.SINGLE,
-    Chem.rdchem.BondType.DOUBLE,
-    Chem.rdchem.BondType.TRIPLE,
-    Chem.rdchem.BondType.AROMATIC,
-]
-"""Vocabulary of allowed bondtypes."""
+if _HAS_RDKIT:
+    ALLOWED_HYBRIDIZATIONS: List[Chem.rdchem.HybridizationType] = [
+        Chem.rdchem.HybridizationType.SP,
+        Chem.rdchem.HybridizationType.SP2,
+        Chem.rdchem.HybridizationType.SP3,
+        Chem.rdchem.HybridizationType.SP3D,
+        Chem.rdchem.HybridizationType.SP3D2,
+    ]
+    """Vocabulary of allowed hybridizations."""
 
-ALLOWED_BOND_TYPE_TO_CHANNEL: Dict[Chem.rdchem.BondType, int] = {
-    Chem.rdchem.BondType.SINGLE: 0,
-    Chem.rdchem.BondType.DOUBLE: 1,
-    Chem.rdchem.BondType.TRIPLE: 2,
-    Chem.rdchem.BondType.AROMATIC: 3,
-}
-"""Mapping of bondtypes to integer values."""
+    ALLOWED_BOND_TYPES: List[Chem.rdchem.BondType] = [
+        Chem.rdchem.BondType.SINGLE,
+        Chem.rdchem.BondType.DOUBLE,
+        Chem.rdchem.BondType.TRIPLE,
+        Chem.rdchem.BondType.AROMATIC,
+    ]
+    """Vocabulary of allowed bondtypes."""
 
+    ALLOWED_BOND_TYPE_TO_CHANNEL: Dict[Chem.rdchem.BondType, int] = {
+        Chem.rdchem.BondType.SINGLE: 0,
+        Chem.rdchem.BondType.DOUBLE: 1,
+        Chem.rdchem.BondType.TRIPLE: 2,
+        Chem.rdchem.BondType.AROMATIC: 3,
+    }
+    """Mapping of bondtypes to integer values."""
 
-ALL_BOND_TYPES: List[Chem.rdchem.BondType] = [
-    Chem.rdchem.BondType.AROMATIC,
-    Chem.rdchem.BondType.DATIVE,
-    Chem.rdchem.BondType.DATIVEL,
-    Chem.rdchem.BondType.DATIVER,
-    Chem.rdchem.BondType.DOUBLE,
-    Chem.rdchem.BondType.FIVEANDAHALF,
-    Chem.rdchem.BondType.FOURANDAHALF,
-    Chem.rdchem.BondType.HEXTUPLE,
-    Chem.rdchem.BondType.HYDROGEN,
-    Chem.rdchem.BondType.IONIC,
-    Chem.rdchem.BondType.ONEANDAHALF,
-    Chem.rdchem.BondType.OTHER,
-    Chem.rdchem.BondType.QUADRUPLE,
-    Chem.rdchem.BondType.QUINTUPLE,
-    Chem.rdchem.BondType.SINGLE,
-    Chem.rdchem.BondType.THREEANDAHALF,
-    Chem.rdchem.BondType.THREECENTER,
-    Chem.rdchem.BondType.TRIPLE,
-    Chem.rdchem.BondType.TWOANDAHALF,
-    Chem.rdchem.BondType.UNSPECIFIED,
-    Chem.rdchem.BondType.ZERO,
-]
-"""Vocabulary of all RDkit BondTypes."""
+    ALL_BOND_TYPES: List[Chem.rdchem.BondType] = [
+        Chem.rdchem.BondType.AROMATIC,
+        Chem.rdchem.BondType.DATIVE,
+        Chem.rdchem.BondType.DATIVEL,
+        Chem.rdchem.BondType.DATIVER,
+        Chem.rdchem.BondType.DOUBLE,
+        Chem.rdchem.BondType.FIVEANDAHALF,
+        Chem.rdchem.BondType.FOURANDAHALF,
+        Chem.rdchem.BondType.HEXTUPLE,
+        Chem.rdchem.BondType.HYDROGEN,
+        Chem.rdchem.BondType.IONIC,
+        Chem.rdchem.BondType.ONEANDAHALF,
+        Chem.rdchem.BondType.OTHER,
+        Chem.rdchem.BondType.QUADRUPLE,
+        Chem.rdchem.BondType.QUINTUPLE,
+        Chem.rdchem.BondType.SINGLE,
+        Chem.rdchem.BondType.THREEANDAHALF,
+        Chem.rdchem.BondType.THREECENTER,
+        Chem.rdchem.BondType.TRIPLE,
+        Chem.rdchem.BondType.TWOANDAHALF,
+        Chem.rdchem.BondType.UNSPECIFIED,
+        Chem.rdchem.BondType.ZERO,
+    ]
+    """Vocabulary of all RDkit BondTypes."""
 
+    ALL_BOND_TYPES_TO_CHANNEL: Dict[Chem.rdchem.BondType, int] = {
+        Chem.rdchem.BondType.AROMATIC: 0,
+        Chem.rdchem.BondType.DATIVE: 1,
+        Chem.rdchem.BondType.DATIVEL: 2,
+        Chem.rdchem.BondType.DATIVER: 3,
+        Chem.rdchem.BondType.DOUBLE: 4,
+        Chem.rdchem.BondType.FIVEANDAHALF: 5,
+        Chem.rdchem.BondType.FOURANDAHALF: 6,
+        Chem.rdchem.BondType.HEXTUPLE: 7,
+        Chem.rdchem.BondType.HYDROGEN: 8,
+        Chem.rdchem.BondType.IONIC: 9,
+        Chem.rdchem.BondType.ONEANDAHALF: 10,
+        Chem.rdchem.BondType.OTHER: 11,
+        Chem.rdchem.BondType.QUADRUPLE: 12,
+        Chem.rdchem.BondType.QUINTUPLE: 13,
+        Chem.rdchem.BondType.SINGLE: 14,
+        Chem.rdchem.BondType.THREEANDAHALF: 15,
+        Chem.rdchem.BondType.THREECENTER: 16,
+        Chem.rdchem.BondType.TRIPLE: 17,
+        Chem.rdchem.BondType.TWOANDAHALF: 18,
+        Chem.rdchem.BondType.UNSPECIFIED: 19,
+        Chem.rdchem.BondType.ZERO: 20,
+    }
+    """Vocabulary of all RDkit BondTypes mapped to integer values."""
 
-ALL_BOND_TYPES_TO_CHANNEL: Dict[Chem.rdchem.BondType, int] = {
-    Chem.rdchem.BondType.AROMATIC: 0,
-    Chem.rdchem.BondType.DATIVE: 1,
-    Chem.rdchem.BondType.DATIVEL: 2,
-    Chem.rdchem.BondType.DATIVER: 3,
-    Chem.rdchem.BondType.DOUBLE: 4,
-    Chem.rdchem.BondType.FIVEANDAHALF: 5,
-    Chem.rdchem.BondType.FOURANDAHALF: 6,
-    Chem.rdchem.BondType.HEXTUPLE: 7,
-    Chem.rdchem.BondType.HYDROGEN: 8,
-    Chem.rdchem.BondType.IONIC: 9,
-    Chem.rdchem.BondType.ONEANDAHALF: 10,
-    Chem.rdchem.BondType.OTHER: 11,
-    Chem.rdchem.BondType.QUADRUPLE: 12,
-    Chem.rdchem.BondType.QUINTUPLE: 13,
-    Chem.rdchem.BondType.SINGLE: 14,
-    Chem.rdchem.BondType.THREEANDAHALF: 15,
-    Chem.rdchem.BondType.THREECENTER: 16,
-    Chem.rdchem.BondType.TRIPLE: 17,
-    Chem.rdchem.BondType.TWOANDAHALF: 18,
-    Chem.rdchem.BondType.UNSPECIFIED: 19,
-    Chem.rdchem.BondType.ZERO: 20,
-}
-"""Vocabulary of all RDkit BondTypes mapped to integer values."""
+    ALL_STEREO_TYPES: List[Chem.rdchem.BondStereo] = [
+        Chem.rdchem.BondStereo.STEREOANY,
+        Chem.rdchem.BondStereo.STEREOCIS,
+        Chem.rdchem.BondStereo.STEREOE,
+        Chem.rdchem.BondStereo.STEREONONE,
+        Chem.rdchem.BondStereo.STEREOTRANS,
+        Chem.rdchem.BondStereo.STEREOZ,
+    ]
+    """Vocabulary of all RDKit bond stereo types."""
 
-ALL_STEREO_TYPES: List[Chem.rdchem.BondStereo] = [
-    Chem.rdchem.BondStereo.STEREOANY,
-    Chem.rdchem.BondStereo.STEREOCIS,
-    Chem.rdchem.BondStereo.STEREOE,
-    Chem.rdchem.BondStereo.STEREONONE,
-    Chem.rdchem.BondStereo.STEREOTRANS,
-    Chem.rdchem.BondStereo.STEREOZ,
-]
-"""Vocabulary of all RDKit bond stereo types."""
+    ALL_STEREO_TO_CHANNEL: Dict[Chem.rdchem.BondStereo, int] = {
+        Chem.rdchem.BondStereo.STEREOANY: 0,
+        Chem.rdchem.BondStereo.STEREOCIS: 1,
+        Chem.rdchem.BondStereo.STEREOE: 2,
+        Chem.rdchem.BondStereo.STEREONONE: 3,
+        Chem.rdchem.BondStereo.STEREOTRANS: 4,
+        Chem.rdchem.BondStereo.STEREOZ: 5,
+    }
+    """Vocabulary of all RDKit bond stereo types mapped to integer values."""
 
-ALL_STEREO_TO_CHANNEL: Dict[Chem.rdchem.BondStereo, int] = {
-    Chem.rdchem.BondStereo.STEREOANY: 0,
-    Chem.rdchem.BondStereo.STEREOCIS: 1,
-    Chem.rdchem.BondStereo.STEREOE: 2,
-    Chem.rdchem.BondStereo.STEREONONE: 3,
-    Chem.rdchem.BondStereo.STEREOTRANS: 4,
-    Chem.rdchem.BondStereo.STEREOZ: 5,
-}
-"""Vocabulary of all RDKit bond stereo types mapped to integer values."""
+    CHIRAL_TYPE: List[Chem.rdchem.ChiralType] = [
+        Chem.rdchem.ChiralType.CHI_OTHER,
+        Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CCW,
+        Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CW,
+        Chem.rdchem.ChiralType.CHI_UNSPECIFIED,
+    ]
+    """Vocabulary of all RDKit chiral types."""
 
-CHIRAL_TYPE: List[Chem.rdchem.ChiralType] = [
-    Chem.rdchem.ChiralType.CHI_OTHER,
-    Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CCW,
-    Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CW,
-    Chem.rdchem.ChiralType.CHI_UNSPECIFIED,
-]
-"""Vocabulary of all RDKit chiral types."""
-
-CHIRAL_TYPE_TO_CHANNEL: Dict[Chem.rdchem.ChiralType, int] = {
-    Chem.rdchem.ChiralType.CHI_OTHER: 0,
-    Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CCW: 1,
-    Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CW: 2,
-    Chem.rdchem.ChiralType.CHI_UNSPECIFIED: 3,
-}
-"""Vocabulary of all RDKit chiral types mapped to integer values."""
+    CHIRAL_TYPE_TO_CHANNEL: Dict[Chem.rdchem.ChiralType, int] = {
+        Chem.rdchem.ChiralType.CHI_OTHER: 0,
+        Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CCW: 1,
+        Chem.rdchem.ChiralType.CHI_TETRAHEDRAL_CW: 2,
+        Chem.rdchem.ChiralType.CHI_UNSPECIFIED: 3,
+    }
+    """Vocabulary of all RDKit chiral types mapped to integer values."""
+else:
+    ALLOWED_HYBRIDIZATIONS: list = []
+    ALLOWED_BOND_TYPES: list = []
+    ALLOWED_BOND_TYPE_TO_CHANNEL: dict = {}
+    ALL_BOND_TYPES: list = []
+    ALL_BOND_TYPES_TO_CHANNEL: dict = {}
+    ALL_STEREO_TYPES: list = []
+    ALL_STEREO_TO_CHANNEL: dict = {}
+    CHIRAL_TYPE: list = []
+    CHIRAL_TYPE_TO_CHANNEL: dict = {}
 
 
 RDKIT_MOL_DESCRIPTORS: List[str] = [


### PR DESCRIPTION
#### Reference Issues/PRs
None found. This is a previously unreported bug.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes
graphein/molecule/atoms.py defines module-level constants using Chem.rdchem.* enums (e.g. ALLOWED_HYBRIDIZATIONS, ALL_BOND_TYPES), but the existing try/except block only guards the import rdkit.
Chem statement. When rdkit is not installed, these constants raise NameError, making import graphein.molecule fail entirely.

This contradicts the design intent visible in other molecule submodules (graphs.py, utils.py) where
rdkit is treated as an optional dependency with a flag-based guard pattern.

Fix: Add a _HAS_RDKIT flag to the existing try/except and wrap rdkit-dependent constants in if _HAS_RDKIT: / else: block with empty fallbacks. Pure Python constants (BASE_ATOMS, EXTENDED_ATOMS,
ALLOWED_DEGREES, etc.) are unchanged.

#### What testing did you do to verify the changes in this PR?
- Verified import graphein.molecule and import graphein.molecule.atoms succeed in a Python environment without rdkit installed
- Ran black --check and isort --check-only on the changed file — both pass

#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [x] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [x] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
