### PR TITLE
drop requirement on RCSB ligand expo after it has been retired

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch: [2.6.0, 2.7.0, 2.8.0]
     # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
     defaults:

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install code style checking tools
         run: python -m pip install black
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install code style checking tools
         run: python -m pip install interrogate
@@ -51,7 +51,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install code style checking tools
         run: python -m pip install isort

--- a/.github/workflows/minimal__install.yaml
+++ b/.github/workflows/minimal__install.yaml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.11]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -2,7 +2,7 @@ pandas
 biopandas>=0.5.1
 biopython
 bioservices>=1.10.0
-cpdb-protein==0.2.0
+cpdb-protein>=0.2.1
 cython
 deepdiff
 loguru

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -14,7 +14,7 @@ numpy<2
 pandas
 plotly
 pydantic
-rcsb-api
+rcsb-api>=1.4.0
 rich
 rich-click
 seaborn

--- a/.requirements/base.in
+++ b/.requirements/base.in
@@ -14,6 +14,7 @@ numpy<2
 pandas
 plotly
 pydantic
+rcsb-api
 rich
 rich-click
 seaborn

--- a/datasets/ppisp/deepPISP.py
+++ b/datasets/ppisp/deepPISP.py
@@ -4,7 +4,7 @@ import pandas as pd
 import torch
 from Bio.PDB import *
 from torch_geometric.data import Data
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from graphein.construct_graphs import ProteinGraph
 

--- a/datasets/pscdb/make_rearrangement_data.py
+++ b/datasets/pscdb/make_rearrangement_data.py
@@ -2,7 +2,7 @@ import argparse
 
 import pandas as pd
 import torch as torch
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from graphein.protein.config import (
     DSSPConfig,

--- a/graphein/ml/__init__.py
+++ b/graphein/ml/__init__.py
@@ -1,6 +1,11 @@
+# graphein/ml/__init__.py
 from .clustering import *
 from .conversion import GraphFormatConvertor
 from .utils import add_labels_to_graph
+
+InMemoryProteinGraphDataset = None
+ProteinGraphDataset = None
+ProteinGraphListDataset = None
 
 try:
     from .datasets import (
@@ -10,6 +15,7 @@ try:
     )
 except (ImportError, NameError):
     pass
+
 try:
     from .visualisation import *
 except (ImportError, NameError):

--- a/graphein/ml/datasets/__init__.py
+++ b/graphein/ml/datasets/__init__.py
@@ -1,5 +1,9 @@
 from .pdb_data import PDBManager
 
+InMemoryProteinGraphDataset = None
+ProteinGraphDataset = None
+ProteinGraphListDataset = None
+
 try:
     from .torch_geometric_dataset import (
         InMemoryProteinGraphDataset,

--- a/graphein/ml/datasets/foldcomp_dataset.py
+++ b/graphein/ml/datasets/foldcomp_dataset.py
@@ -223,7 +223,9 @@ class FoldCompDataset(Dataset):
     def download(self):
         """Downloads foldcomp database if not already downloaded."""
 
-        if not all(os.path.exists(self.root / f) for f in self._database_files):
+        if not all(
+            os.path.exists(self.root / f) for f in self._database_files
+        ):
             log.info(f"Downloading FoldComp dataset {self.database}...")
             curr_dir = os.getcwd()
             os.chdir(self.root)
@@ -264,7 +266,9 @@ class FoldCompDataset(Dataset):
             ]
         # Sub sample
         log.info(f"Sampling fraction: {self.fraction}...")
-        accessions = random.sample(accessions, int(len(accessions) * self.fraction))
+        accessions = random.sample(
+            accessions, int(len(accessions) * self.fraction)
+        )
         self.ids = accessions
         log.info("Creating index...")
         indices = dict(enumerate(accessions))
@@ -397,7 +401,9 @@ class FoldCompLightningDataModule(L.LightningDataModule):
         self.val_split = val_split
         self.test_split = test_split
         self.transform = (
-            self._compose_transforms(transform) if transform is not None else None
+            self._compose_transforms(transform)
+            if transform is not None
+            else None
         )
 
         if (
@@ -439,7 +445,9 @@ class FoldCompLightningDataModule(L.LightningDataModule):
         self.ids = ds.ids
         ds.db.close()
 
-    def _split_data(self, train_split: float, val_split: float, test_split: float):
+    def _split_data(
+        self, train_split: float, val_split: float, test_split: float
+    ):
         """Split the database into non-overlapping train, validation and test"""
         if not hasattr(self, "ids"):
             self._get_indices()

--- a/graphein/ml/datasets/foldcomp_dataset.py
+++ b/graphein/ml/datasets/foldcomp_dataset.py
@@ -29,7 +29,7 @@ from sklearn.model_selection import train_test_split
 from torch_geometric import transforms as T
 from torch_geometric.data import Data, Dataset
 from torch_geometric.loader import DataLoader
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from graphein.protein.resi_atoms import (
     ATOM_NUMBERING,
@@ -223,9 +223,7 @@ class FoldCompDataset(Dataset):
     def download(self):
         """Downloads foldcomp database if not already downloaded."""
 
-        if not all(
-            os.path.exists(self.root / f) for f in self._database_files
-        ):
+        if not all(os.path.exists(self.root / f) for f in self._database_files):
             log.info(f"Downloading FoldComp dataset {self.database}...")
             curr_dir = os.getcwd()
             os.chdir(self.root)
@@ -266,9 +264,7 @@ class FoldCompDataset(Dataset):
             ]
         # Sub sample
         log.info(f"Sampling fraction: {self.fraction}...")
-        accessions = random.sample(
-            accessions, int(len(accessions) * self.fraction)
-        )
+        accessions = random.sample(accessions, int(len(accessions) * self.fraction))
         self.ids = accessions
         log.info("Creating index...")
         indices = dict(enumerate(accessions))
@@ -401,9 +397,7 @@ class FoldCompLightningDataModule(L.LightningDataModule):
         self.val_split = val_split
         self.test_split = test_split
         self.transform = (
-            self._compose_transforms(transform)
-            if transform is not None
-            else None
+            self._compose_transforms(transform) if transform is not None else None
         )
 
         if (
@@ -445,9 +439,7 @@ class FoldCompLightningDataModule(L.LightningDataModule):
         self.ids = ds.ids
         ds.db.close()
 
-    def _split_data(
-        self, train_split: float, val_split: float, test_split: float
-    ):
+    def _split_data(self, train_split: float, val_split: float, test_split: float):
         """Split the database into non-overlapping train, validation and test"""
         if not hasattr(self, "ids"):
             self._get_indices()

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -354,7 +354,7 @@ class PDBManager:
             log.debug("Unzipped sequences")
 
     def _generate_ligand_map(self):
-        """Download ligand map from
+        """Generate ligand map to match historical ligand map located at:
         http://ligand-expo.rcsb.org/dictionaries/cc-to-pdb.tdd.
         """
         if not os.path.exists(self.root_dir / self.ligand_map_filename):
@@ -672,8 +672,7 @@ class PDBManager:
             seq = v
             params = k.split()
             pdb_id = params[0]
-            pdb = params[0].split("_")[0]
-            chain = params[0].split("_")[1]
+            pdb, chain = pdb_id.split("_", 1)
             length = int(params[2].split(":")[1])
             molecule_type = params[1].split(":")[1]
             name = " ".join(params[3:])

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -37,7 +37,9 @@ class PDBManager:
         split_ratios: Optional[List[float]] = None,
         split_time_frames: Optional[List[np.datetime64]] = None,
         assign_leftover_rows_to_split_n: int = 0,
-        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
+        labels: Optional[
+            List[Literal["uniprot_id", "cath_code", "ec_number"]]
+        ] = None,
     ):
         """Instantiate a selection of experimental PDB structures.
 
@@ -83,9 +85,7 @@ class PDBManager:
         self.pdb_deposition_date_url = (
             "https://files.wwpdb.org/pub/pdb/derived_data/index/entries.idx"
         )
-        self.pdb_availability_url = (
-            "https://files.wwpdb.org/pub/pdb/compatible/pdb_bundle/pdb_bundle_index.txt"
-        )
+        self.pdb_availability_url = "https://files.wwpdb.org/pub/pdb/compatible/pdb_bundle/pdb_bundle_index.txt"
 
         self.pdb_chain_cath_uniprot_url = "https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_cath_uniprot.tsv.gz"
 
@@ -105,13 +105,17 @@ class PDBManager:
         self.source_map_filename = Path(self.source_map_url).name
         self.resolution_filename = Path(self.resolution_url).name
         self.pdb_entry_type_filename = Path(self.pdb_entry_type_url).name
-        self.pdb_deposition_date_filename = Path(self.pdb_deposition_date_url).name
+        self.pdb_deposition_date_filename = Path(
+            self.pdb_deposition_date_url
+        ).name
         self.pdb_availability_filename = Path(self.pdb_availability_url).name
         self.pdb_chain_cath_uniprot_filename = Path(
             self.pdb_chain_cath_uniprot_url
         ).name
         self.cath_id_cath_code_filename = Path(self.cath_id_cath_code_url).name
-        self.pdb_chain_ec_number_filename = Path(self.pdb_chain_ec_number_url).name
+        self.pdb_chain_ec_number_filename = Path(
+            self.pdb_chain_ec_number_url
+        ).name
 
         self.list_columns = ["ligands"]
 
@@ -128,11 +132,13 @@ class PDBManager:
             ), f"Split names must be unique: {splits}."
             self.splits = splits
             self.df_splits = {split: None for split in splits}
-            self.assign_leftover_rows_to_split_n = assign_leftover_rows_to_split_n
+            self.assign_leftover_rows_to_split_n = (
+                assign_leftover_rows_to_split_n
+            )
             # Sequence-based ratio splits
             if split_ratios is not None:
-                assert (
-                    len(splits) == len(split_ratios)
+                assert len(splits) == len(
+                    split_ratios
                 ), f"Number of splits ({splits}) must match number of split ratios ({split_ratios})."
                 assert math.isclose(
                     sum(split_ratios), 1.0
@@ -140,8 +146,8 @@ class PDBManager:
                 self.split_ratios = split_ratios
             # Time-based splits
             if split_time_frames is not None:
-                assert (
-                    len(splits) == len(split_time_frames)
+                assert len(splits) == len(
+                    split_time_frames
                 ), f"Number of splits ({splits}) must match number of split time frames ({split_time_frames})."
                 assert self._frames_are_sequential(
                     split_time_frames
@@ -173,7 +179,9 @@ class PDBManager:
         :rtype: List[str]
         """
         splits_df = self.get_splits(splits)
-        return splits_df.loc[splits_df.pdb_file_available == False, "pdb"].tolist()
+        return splits_df.loc[
+            splits_df.pdb_file_available == False, "pdb"
+        ].tolist()
 
     def get_num_unique_pdbs(self, splits: Optional[List[str]] = None) -> int:
         """Return the number of unique PDB IDs in the dataset.
@@ -253,7 +261,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.resolution.min()
 
-    def get_worst_resolution(self, splits: Optional[List[str]] = None) -> float:
+    def get_worst_resolution(
+        self, splits: Optional[List[str]] = None
+    ) -> float:
         """Return the worst resolution in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -266,7 +276,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.resolution.max()
 
-    def get_experiment_types(self, splits: Optional[List[str]] = None) -> List[str]:
+    def get_experiment_types(
+        self, splits: Optional[List[str]] = None
+    ) -> List[str]:
         """Return list of different experiment types in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -279,7 +291,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.experiment_type.unique()
 
-    def get_molecule_types(self, splits: Optional[List[str]] = None) -> List[str]:
+    def get_molecule_types(
+        self, splits: Optional[List[str]] = None
+    ) -> List[str]:
         """Return list of different molecule types in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -292,7 +306,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.molecule_type.unique()
 
-    def get_molecule_names(self, splits: Optional[List[str]] = None) -> List[str]:
+    def get_molecule_names(
+        self, splits: Optional[List[str]] = None
+    ) -> List[str]:
         """Return list of molecule names in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -305,7 +321,9 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.name.unique()
 
-    def _frames_are_sequential(self, split_time_frames: List[np.datetime64]) -> bool:
+    def _frames_are_sequential(
+        self, split_time_frames: List[np.datetime64]
+    ) -> bool:
         """Check if all provided frames are sequentially ordered.
 
         :param split_time_frames: Time frames into which to split
@@ -338,7 +356,9 @@ class PDBManager:
         """Download PDB sequences from
         https://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt.gz.
         """
-        if not os.path.exists(self.root_dir / self.pdb_seqres_archive_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_seqres_archive_filename
+        ):
             log.info("Downloading PDB sequences...")
             wget.download(self.pdb_sequences_url, out=str(self.root_dir))
             log.debug("Downloaded sequences")
@@ -349,7 +369,9 @@ class PDBManager:
             with gzip.open(
                 self.root_dir / self.pdb_seqres_archive_filename, "rb"
             ) as f_in:
-                with open(self.root_dir / self.pdb_seqres_filename, "wb") as f_out:
+                with open(
+                    self.root_dir / self.pdb_seqres_filename, "wb"
+                ) as f_out:
                     shutil.copyfileobj(f_in, f_out)
             log.debug("Unzipped sequences")
 
@@ -387,7 +409,9 @@ class PDBManager:
         """Download PDB entry metadata from
         https://files.wwpdb.org/pub/pdb/derived_data/index/entries.idx.
         """
-        if not os.path.exists(self.root_dir / self.pdb_deposition_date_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_deposition_date_filename
+        ):
             log.info("Downloading entry metadata...")
             wget.download(self.pdb_deposition_date_url, out=str(self.root_dir))
             log.debug("Downloaded entry metadata")
@@ -414,9 +438,13 @@ class PDBManager:
         """Download mapping from PDB chain to uniprot accession and CATH ID from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_cath_uniprot.tsv.gz
         """
-        if not os.path.exists(self.root_dir / self.pdb_chain_cath_uniprot_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename
+        ):
             log.info("Downloading Uniprot CATH map...")
-            wget.download(self.pdb_chain_cath_uniprot_url, out=str(self.root_dir))
+            wget.download(
+                self.pdb_chain_cath_uniprot_url, out=str(self.root_dir)
+            )
             log.debug("Downloaded Uniprot CATH map")
 
     def _download_cath_id_cath_code_map(self):
@@ -432,7 +460,9 @@ class PDBManager:
         """Download mapping from PDB chains to EC number from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_enzyme.tsv.gz
         """
-        if not os.path.exists(self.root_dir / self.pdb_chain_ec_number_filename):
+        if not os.path.exists(
+            self.root_dir / self.pdb_chain_ec_number_filename
+        ):
             log.info("Downloading EC number map...")
             wget.download(self.pdb_chain_ec_number_url, out=str(self.root_dir))
             log.debug("Downloaded EC number map")
@@ -570,7 +600,9 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         uniprot_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt") as f:
+        with gzip.open(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
+        ) as f:
             for line in f:
                 try:
                     pdb, chain, uniprot_id, cath_id = line.strip().split("\t")
@@ -588,7 +620,9 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         cath_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt") as f:
+        with gzip.open(
+            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
+        ) as f:
             next(f)  # Skip header line
             for line in f:
                 try:
@@ -638,11 +672,15 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         ec_mapping = {}
-        with gzip.open(self.root_dir / self.pdb_chain_ec_number_filename, "rt") as f:
+        with gzip.open(
+            self.root_dir / self.pdb_chain_ec_number_filename, "rt"
+        ) as f:
             next(f)  # Skip header line
             for line in f:
                 try:
-                    pdb, chain, uniprot_id, ec_number = line.strip().split("\t")
+                    pdb, chain, uniprot_id, ec_number = line.strip().split(
+                        "\t"
+                    )
                     key = f"{pdb}_{chain}"
                     ec_number = None if ec_number == "?" else ec_number
                     ec_mapping[key] = ec_number
@@ -652,7 +690,9 @@ class PDBManager:
 
     def parse(
         self,
-        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
+        labels: Optional[
+            List[Literal["uniprot_id", "cath_code", "ec_number"]]
+        ] = None,
     ) -> pd.DataFrame:
         """Parse all PDB sequence records.
 
@@ -948,24 +988,32 @@ class PDBManager:
 
         if comparison == "equal":
             df = (
-                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") == length]
+                splits_df[
+                    splits_df.groupby("pdb")["pdb"].transform("size") == length
+                ]
                 if compare_pdb_groups
                 else splits_df[splits_df.length == length]
             )
         elif comparison == "less":
             df = (
-                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") < length]
+                splits_df[
+                    splits_df.groupby("pdb")["pdb"].transform("size") < length
+                ]
                 if compare_pdb_groups
                 else splits_df[splits_df.length < length]
             )
         elif comparison == "greater":
             df = (
-                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") > length]
+                splits_df[
+                    splits_df.groupby("pdb")["pdb"].transform("size") > length
+                ]
                 if compare_pdb_groups
                 else splits_df[splits_df.length > length]
             )
         else:
-            raise ValueError("Comparison must be one of 'equal', 'less', or 'greater'.")
+            raise ValueError(
+                "Comparison must be one of 'equal', 'less', or 'greater'."
+            )
 
         if update:
             self.df = df
@@ -1074,7 +1122,9 @@ class PDBManager:
         elif comparison == "greater":
             df = splits_df.loc[splits_df.n_chains >= oligomer]
         else:
-            raise ValueError("Comparison must be one of 'equal', 'less', or 'greater'.")
+            raise ValueError(
+                "Comparison must be one of 'equal', 'less', or 'greater'."
+            )
         if update:
             self.df = df
         return df
@@ -1398,8 +1448,8 @@ class PDBManager:
         :return: Dictionary of DataFrame splits.
         :rtype: Dict[str, pd.DataFrame]
         """
-        assert (
-            len(splits) == len(split_ratios)
+        assert len(splits) == len(
+            split_ratios
         ), f"Number of splits ({len(splits)}) must match number of split ratios ({len(split_ratios)})"
         assert (
             sum(split_ratios) == 1
@@ -1414,7 +1464,9 @@ class PDBManager:
             split_sizes[assign_leftover_rows_to_split_n] += num_remaining_rows
 
         # Without replacement, randomly shuffle rows within the input DataFrame
-        df_sampled = df.sample(frac=1.0, replace=False, random_state=random_state)
+        df_sampled = df.sample(
+            frac=1.0, replace=False, random_state=random_state
+        )
 
         # Split DataFrames
         start_idx = 0
@@ -1438,7 +1490,9 @@ class PDBManager:
         df_split_sizes = " ".join(
             [str(df_splits[split].shape[0]) for split in df_splits]
         )
-        log.info(f"Proportionally-derived dataset splits of sizes: {df_split_sizes}")
+        log.info(
+            f"Proportionally-derived dataset splits of sizes: {df_split_sizes}"
+        )
 
         return df_splits
 
@@ -1573,7 +1627,9 @@ class PDBManager:
         # Build name of FASTA and cluster files
         if cluster_fname is None:
             fasta_fname = "pdb.fasta"
-            cluster_fname = f"pdb_cluster_rep_seq_id_{min_seq_id}_c_{coverage}.fasta"
+            cluster_fname = (
+                f"pdb_cluster_rep_seq_id_{min_seq_id}_c_{coverage}.fasta"
+            )
 
         # Do clustering if overwriting or no clusters were found
         if not os.path.exists(self.root_dir / cluster_fname) or overwrite:
@@ -1587,7 +1643,9 @@ class PDBManager:
             # Create clusters
             log.info("Creating clusters...")
             # Write selection to FASTA
-            log.info(f"Writing current selection ({len(self.df)} chains) to FASTA...")
+            log.info(
+                f"Writing current selection ({len(self.df)} chains) to FASTA..."
+            )
             self.to_fasta(str(self.root_dir / fasta_fname))
             if not is_tool("mmseqs"):
                 log.error(
@@ -1598,7 +1656,9 @@ class PDBManager:
                 cmd = f"mmseqs easy-cluster {str(self.root_dir / fasta_fname)} pdb_cluster tmp --min-seq-id {min_seq_id} -c {coverage} --cov-mode 1"
                 log.info(f"Clustering with: {cmd}")
                 subprocess.run(cmd.split())
-                os.rename("pdb_cluster_rep_seq.fasta", self.root_dir / cluster_fname)
+                os.rename(
+                    "pdb_cluster_rep_seq.fasta", self.root_dir / cluster_fname
+                )
                 log.info("Done clustering!")
         # Otherwise, read from disk
         elif os.path.exists(self.root_dir / cluster_fname):
@@ -1635,8 +1695,8 @@ class PDBManager:
         :return: Dictionary of DataFrame splits.
         :rtype: Dict[str, pd.DataFrame]
         """
-        assert (
-            len(splits) == len(split_time_frames)
+        assert len(splits) == len(
+            split_time_frames
         ), f"Number of splits ({len(splits)}) must match number of time frames ({len(split_time_frames)})."
         assert self._frames_are_sequential(
             split_time_frames
@@ -1670,14 +1730,18 @@ class PDBManager:
             len(all_splits_df) == len(df) - num_remaining_rows
         ), "Number of rows changed during split operations."
         assert (
-            len(all_splits_df.drop(self.list_columns, axis=1).drop_duplicates())
+            len(
+                all_splits_df.drop(self.list_columns, axis=1).drop_duplicates()
+            )
             == len(df) - num_remaining_rows
         ), "Duplicate rows found in splits."
 
         df_split_sizes = " ".join(
             [str(df_splits[split].shape[0]) for split in df_splits]
         )
-        log.info(f"Deposition date-derived dataset splits of sizes: {df_split_sizes}")
+        log.info(
+            f"Deposition date-derived dataset splits of sizes: {df_split_sizes}"
+        )
 
         return df_splits
 
@@ -1699,7 +1763,9 @@ class PDBManager:
         :rtype: Dict[str, pd.DataFrame]
         """
         split_time_frames_provided = self.split_time_frames is not None
-        assert split_time_frames_provided, "Split time frames must be provided."
+        assert (
+            split_time_frames_provided
+        ), "Split time frames must be provided."
 
         # Split sequences
         time_frames = " ".join([str(f) for f in self.split_time_frames])
@@ -1742,12 +1808,18 @@ class PDBManager:
         :rtype: Union[pd.DataFrame, Dict[str, pd.DataFrame]]
         """
         # Drop missing deposition dates
-        df = self.df.dropna().loc[self.df.deposition_date < max_deposition_date]
+        df = self.df.dropna().loc[
+            self.df.deposition_date < max_deposition_date
+        ]
         if update:
             self.df = df
 
         # Split sequences
-        return self.split_by_deposition_date(df, update) if self.splits_provided else df
+        return (
+            self.split_by_deposition_date(df, update)
+            if self.splits_provided
+            else df
+        )
 
     def reset(self) -> pd.DataFrame:
         """Reset the dataset to the original DataFrame source.
@@ -1783,7 +1855,9 @@ class PDBManager:
         :param chunksize: Chunk size for each worker, defaults to ``32``.
         :type chunksize: int, optional
         """
-        log.info(f"Downloading {len(self.get_unique_pdbs(splits))} PDB files...")
+        log.info(
+            f"Downloading {len(self.get_unique_pdbs(splits))} PDB files..."
+        )
         download_pdb_multiprocessing(
             self.get_unique_pdbs(splits),
             out_dir,
@@ -1827,23 +1901,33 @@ class PDBManager:
 
         # Check we have all source PDB files
         downloaded = os.listdir(self.pdb_dir)
-        downloaded = [f for f in downloaded if f.endswith(f".{self.structure_format}")]
+        downloaded = [
+            f for f in downloaded if f.endswith(f".{self.structure_format}")
+        ]
 
         to_download = [
-            k for k in df.keys() if f"{k}.{self.structure_format}" not in downloaded
+            k
+            for k in df.keys()
+            if f"{k}.{self.structure_format}" not in downloaded
         ]
         if len(to_download) > 0:
             log.info(f"Downloading {len(to_download)} PDB files...")
-            download_pdb_multiprocessing(to_download, self.pdb_dir, overwrite=True)
+            download_pdb_multiprocessing(
+                to_download, self.pdb_dir, overwrite=True
+            )
             log.info("Done downloading PDB files")
 
         # Iterate over dictionary and write chains to separate files
         log.info("Extracting chains...")
         paths = []
         for k, v in tqdm(df.items()):
-            in_file = os.path.join(self.pdb_dir, f"{k}.{self.structure_format}")
+            in_file = os.path.join(
+                self.pdb_dir, f"{k}.{self.structure_format}"
+            )
             paths.append(
-                extract_chains_to_file(in_file, v, out_dir=self.pdb_dir, models=models)
+                extract_chains_to_file(
+                    in_file, v, out_dir=self.pdb_dir, models=models
+                )
             )
         log.info("Done extracting chains")
 
@@ -1875,7 +1959,9 @@ class PDBManager:
         elif ids == "pdb":
             return splits_df.loc[splits_df.pdb.isin(seq_ids)]
         else:
-            raise ValueError("Invalid parameter ids. Must be 'chain' or 'pdb'.")
+            raise ValueError(
+                "Invalid parameter ids. Must be 'chain' or 'pdb'."
+            )
 
     def to_chain_sequence_mapping_dict(
         self, splits: Optional[List[str]]
@@ -1891,7 +1977,9 @@ class PDBManager:
         """
         splits_df = self.get_splits(splits)
         self._check_download_availability(splits_df, raise_error=False)
-        return splits_df[["id", "sequence"]].set_index("id").to_dict()["sequence"]
+        return (
+            splits_df[["id", "sequence"]].set_index("id").to_dict()["sequence"]
+        )
 
     def to_fasta(self, filename: str, splits: Optional[List[str]] = None):
         """Write the dataset to a FASTA file (indexed by chain id).
@@ -1902,7 +1990,9 @@ class PDBManager:
             defaults to ``None``.
         :type splits: Optional[List[str]], optional
         """
-        self._check_download_availability(self.get_splits(splits), raise_error=False)
+        self._check_download_availability(
+            self.get_splits(splits), raise_error=False
+        )
         with open(filename, "w") as f:
             for k, v in self.to_chain_sequence_mapping_dict(splits).items():
                 f.write(f">{k}\n")
@@ -1922,7 +2012,9 @@ class PDBManager:
             unavailable PDB files are found in ``df``.
         """
         if not all(df.pdb_file_available):
-            unavailable = df.loc[df.pdb_file_available == False, "pdb"].to_list()
+            unavailable = df.loc[
+                df.pdb_file_available == False, "pdb"
+            ].to_list()
             if raise_error:
                 raise ValueError(
                     f"You are exporting a selection that contains {len(unavailable)} PDB(s) unavailable for download in PDB format: {unavailable}"
@@ -1943,7 +2035,9 @@ class PDBManager:
         """
         splits_df = self.get_splits(splits)
         self._check_download_availability(splits_df, raise_error=False)
-        log.info(f"Writing selection ({len(splits_df)} chains) to CSV file: {fname}")
+        log.info(
+            f"Writing selection ({len(splits_df)} chains) to CSV file: {fname}"
+        )
 
         splits_df.to_csv(fname, index=False)
 
@@ -1984,7 +2078,9 @@ class PDBManager:
         """
         for key in pdb.df:
             if field in pdb.df[key]:
-                filtered_pdb = pdb.df[key][pdb.df[key][field].isin(field_values)]
+                filtered_pdb = pdb.df[key][
+                    pdb.df[key][field].isin(field_values)
+                ]
                 if "ATOM" in key and len(filtered_pdb) == 0:
                     log.warning(
                         f"DataFrame for PDB {pdb_code} does not contain any standard atoms after filtering"
@@ -2058,11 +2154,17 @@ class PDBManager:
                         )
                         continue
                     # work around int-typing bug for `model_id` within version `0.5.0.dev0` of BioPandas -> appears when calling `to_pdb()`
-                    cast_pdb_column_to_type(pdb, column_name="model_id", type=str)
+                    cast_pdb_column_to_type(
+                        pdb, column_name="model_id", type=str
+                    )
                     # select only from chains available in the PDB file
-                    pdb_atom_chains = pdb.df[atom_df_name].chain_id.unique().tolist()
+                    pdb_atom_chains = (
+                        pdb.df[atom_df_name].chain_id.unique().tolist()
+                    )
                     chains = [
-                        chain for chain in entry_chains if chain in pdb_atom_chains
+                        chain
+                        for chain in entry_chains
+                        if chain in pdb_atom_chains
                     ]
                     chains = (
                         chains

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -14,8 +14,9 @@ import wget
 from biopandas.pdb import PandasPdb
 from loguru import logger as log
 from pandas.core.groupby.generic import DataFrameGroupBy
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
+from graphein.ml.datasets.utils import generate_pdb_ligand_mappings
 from graphein.protein.utils import (
     cast_pdb_column_to_type,
     download_pdb_multiprocessing,
@@ -36,9 +37,7 @@ class PDBManager:
         split_ratios: Optional[List[float]] = None,
         split_time_frames: Optional[List[np.datetime64]] = None,
         assign_leftover_rows_to_split_n: int = 0,
-        labels: Optional[
-            List[Literal["uniprot_id", "cath_code", "ec_number"]]
-        ] = None,
+        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
     ):
         """Instantiate a selection of experimental PDB structures.
 
@@ -72,9 +71,6 @@ class PDBManager:
         self.pdb_sequences_url = (
             "https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt.gz"
         )
-        self.ligand_map_url = (
-            "http://ligand-expo.rcsb.org/dictionaries/cc-to-pdb.tdd"
-        )
         self.source_map_url = (
             "https://files.wwpdb.org/pub/pdb/derived_data/index/source.idx"
         )
@@ -87,7 +83,9 @@ class PDBManager:
         self.pdb_deposition_date_url = (
             "https://files.wwpdb.org/pub/pdb/derived_data/index/entries.idx"
         )
-        self.pdb_availability_url = "https://files.wwpdb.org/pub/pdb/compatible/pdb_bundle/pdb_bundle_index.txt"
+        self.pdb_availability_url = (
+            "https://files.wwpdb.org/pub/pdb/compatible/pdb_bundle/pdb_bundle_index.txt"
+        )
 
         self.pdb_chain_cath_uniprot_url = "https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_cath_uniprot.tsv.gz"
 
@@ -103,21 +101,17 @@ class PDBManager:
 
         self.pdb_seqres_archive_filename = Path(self.pdb_sequences_url).name
         self.pdb_seqres_filename = Path(self.pdb_seqres_archive_filename).stem
-        self.ligand_map_filename = Path(self.ligand_map_url).name
+        self.ligand_map_filename = "cc-to-pdb.tdd"
         self.source_map_filename = Path(self.source_map_url).name
         self.resolution_filename = Path(self.resolution_url).name
         self.pdb_entry_type_filename = Path(self.pdb_entry_type_url).name
-        self.pdb_deposition_date_filename = Path(
-            self.pdb_deposition_date_url
-        ).name
+        self.pdb_deposition_date_filename = Path(self.pdb_deposition_date_url).name
         self.pdb_availability_filename = Path(self.pdb_availability_url).name
         self.pdb_chain_cath_uniprot_filename = Path(
             self.pdb_chain_cath_uniprot_url
         ).name
         self.cath_id_cath_code_filename = Path(self.cath_id_cath_code_url).name
-        self.pdb_chain_ec_number_filename = Path(
-            self.pdb_chain_ec_number_url
-        ).name
+        self.pdb_chain_ec_number_filename = Path(self.pdb_chain_ec_number_url).name
 
         self.list_columns = ["ligands"]
 
@@ -134,13 +128,11 @@ class PDBManager:
             ), f"Split names must be unique: {splits}."
             self.splits = splits
             self.df_splits = {split: None for split in splits}
-            self.assign_leftover_rows_to_split_n = (
-                assign_leftover_rows_to_split_n
-            )
+            self.assign_leftover_rows_to_split_n = assign_leftover_rows_to_split_n
             # Sequence-based ratio splits
             if split_ratios is not None:
-                assert len(splits) == len(
-                    split_ratios
+                assert (
+                    len(splits) == len(split_ratios)
                 ), f"Number of splits ({splits}) must match number of split ratios ({split_ratios})."
                 assert math.isclose(
                     sum(split_ratios), 1.0
@@ -148,8 +140,8 @@ class PDBManager:
                 self.split_ratios = split_ratios
             # Time-based splits
             if split_time_frames is not None:
-                assert len(splits) == len(
-                    split_time_frames
+                assert (
+                    len(splits) == len(split_time_frames)
                 ), f"Number of splits ({splits}) must match number of split time frames ({split_time_frames})."
                 assert self._frames_are_sequential(
                     split_time_frames
@@ -159,7 +151,7 @@ class PDBManager:
     def download_metadata(self):
         """Download all PDB metadata."""
         self._download_pdb_sequences()
-        self._download_ligand_map()
+        self._generate_ligand_map()
         self._download_source_map()
         self._download_resolution()
         self._download_entry_metadata()
@@ -181,9 +173,7 @@ class PDBManager:
         :rtype: List[str]
         """
         splits_df = self.get_splits(splits)
-        return splits_df.loc[
-            splits_df.pdb_file_available == False, "pdb"
-        ].tolist()
+        return splits_df.loc[splits_df.pdb_file_available == False, "pdb"].tolist()
 
     def get_num_unique_pdbs(self, splits: Optional[List[str]] = None) -> int:
         """Return the number of unique PDB IDs in the dataset.
@@ -263,9 +253,7 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.resolution.min()
 
-    def get_worst_resolution(
-        self, splits: Optional[List[str]] = None
-    ) -> float:
+    def get_worst_resolution(self, splits: Optional[List[str]] = None) -> float:
         """Return the worst resolution in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -278,9 +266,7 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.resolution.max()
 
-    def get_experiment_types(
-        self, splits: Optional[List[str]] = None
-    ) -> List[str]:
+    def get_experiment_types(self, splits: Optional[List[str]] = None) -> List[str]:
         """Return list of different experiment types in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -293,9 +279,7 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.experiment_type.unique()
 
-    def get_molecule_types(
-        self, splits: Optional[List[str]] = None
-    ) -> List[str]:
+    def get_molecule_types(self, splits: Optional[List[str]] = None) -> List[str]:
         """Return list of different molecule types in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -308,9 +292,7 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.molecule_type.unique()
 
-    def get_molecule_names(
-        self, splits: Optional[List[str]] = None
-    ) -> List[str]:
+    def get_molecule_names(self, splits: Optional[List[str]] = None) -> List[str]:
         """Return list of molecule names in the dataset.
 
         :param splits: Names of splits for which to perform the operation,
@@ -323,9 +305,7 @@ class PDBManager:
         splits_df = self.get_splits(splits)
         return splits_df.name.unique()
 
-    def _frames_are_sequential(
-        self, split_time_frames: List[np.datetime64]
-    ) -> bool:
+    def _frames_are_sequential(self, split_time_frames: List[np.datetime64]) -> bool:
         """Check if all provided frames are sequentially ordered.
 
         :param split_time_frames: Time frames into which to split
@@ -358,9 +338,7 @@ class PDBManager:
         """Download PDB sequences from
         https://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt.gz.
         """
-        if not os.path.exists(
-            self.root_dir / self.pdb_seqres_archive_filename
-        ):
+        if not os.path.exists(self.root_dir / self.pdb_seqres_archive_filename):
             log.info("Downloading PDB sequences...")
             wget.download(self.pdb_sequences_url, out=str(self.root_dir))
             log.debug("Downloaded sequences")
@@ -371,20 +349,21 @@ class PDBManager:
             with gzip.open(
                 self.root_dir / self.pdb_seqres_archive_filename, "rb"
             ) as f_in:
-                with open(
-                    self.root_dir / self.pdb_seqres_filename, "wb"
-                ) as f_out:
+                with open(self.root_dir / self.pdb_seqres_filename, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
             log.debug("Unzipped sequences")
 
-    def _download_ligand_map(self):
+    def _generate_ligand_map(self):
         """Download ligand map from
         http://ligand-expo.rcsb.org/dictionaries/cc-to-pdb.tdd.
         """
         if not os.path.exists(self.root_dir / self.ligand_map_filename):
-            log.info("Downloading ligand map...")
-            wget.download(self.ligand_map_url, out=str(self.root_dir))
-            log.debug("Downloaded ligand map")
+            log.info("Generating chemical component to PDB map...")
+            generate_pdb_ligand_mappings(
+                pdb_to_cc_output_file=self.root_dir / self.ligand_map_filename,
+                cc_to_pdb_output_file=self.root_dir / self.ligand_map_filename,
+                generate_cc_extra_file=False,
+            )
 
     def _download_source_map(self):
         """Download source map from
@@ -408,9 +387,7 @@ class PDBManager:
         """Download PDB entry metadata from
         https://files.wwpdb.org/pub/pdb/derived_data/index/entries.idx.
         """
-        if not os.path.exists(
-            self.root_dir / self.pdb_deposition_date_filename
-        ):
+        if not os.path.exists(self.root_dir / self.pdb_deposition_date_filename):
             log.info("Downloading entry metadata...")
             wget.download(self.pdb_deposition_date_url, out=str(self.root_dir))
             log.debug("Downloaded entry metadata")
@@ -437,13 +414,9 @@ class PDBManager:
         """Download mapping from PDB chain to uniprot accession and CATH ID from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_cath_uniprot.tsv.gz
         """
-        if not os.path.exists(
-            self.root_dir / self.pdb_chain_cath_uniprot_filename
-        ):
+        if not os.path.exists(self.root_dir / self.pdb_chain_cath_uniprot_filename):
             log.info("Downloading Uniprot CATH map...")
-            wget.download(
-                self.pdb_chain_cath_uniprot_url, out=str(self.root_dir)
-            )
+            wget.download(self.pdb_chain_cath_uniprot_url, out=str(self.root_dir))
             log.debug("Downloaded Uniprot CATH map")
 
     def _download_cath_id_cath_code_map(self):
@@ -459,9 +432,7 @@ class PDBManager:
         """Download mapping from PDB chains to EC number from
         https://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_enzyme.tsv.gz
         """
-        if not os.path.exists(
-            self.root_dir / self.pdb_chain_ec_number_filename
-        ):
+        if not os.path.exists(self.root_dir / self.pdb_chain_ec_number_filename):
             log.info("Downloading EC number map...")
             wget.download(self.pdb_chain_ec_number_url, out=str(self.root_dir))
             log.debug("Downloaded EC number map")
@@ -599,9 +570,7 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         uniprot_mapping = {}
-        with gzip.open(
-            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
-        ) as f:
+        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt") as f:
             for line in f:
                 try:
                     pdb, chain, uniprot_id, cath_id = line.strip().split("\t")
@@ -619,9 +588,7 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         cath_mapping = {}
-        with gzip.open(
-            self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt"
-        ) as f:
+        with gzip.open(self.root_dir / self.pdb_chain_cath_uniprot_filename, "rt") as f:
             next(f)  # Skip header line
             for line in f:
                 try:
@@ -671,15 +638,11 @@ class PDBManager:
         :rtype: Dict[str, str]
         """
         ec_mapping = {}
-        with gzip.open(
-            self.root_dir / self.pdb_chain_ec_number_filename, "rt"
-        ) as f:
+        with gzip.open(self.root_dir / self.pdb_chain_ec_number_filename, "rt") as f:
             next(f)  # Skip header line
             for line in f:
                 try:
-                    pdb, chain, uniprot_id, ec_number = line.strip().split(
-                        "\t"
-                    )
+                    pdb, chain, uniprot_id, ec_number = line.strip().split("\t")
                     key = f"{pdb}_{chain}"
                     ec_number = None if ec_number == "?" else ec_number
                     ec_mapping[key] = ec_number
@@ -689,9 +652,7 @@ class PDBManager:
 
     def parse(
         self,
-        labels: Optional[
-            List[Literal["uniprot_id", "cath_code", "ec_number"]]
-        ] = None,
+        labels: Optional[List[Literal["uniprot_id", "cath_code", "ec_number"]]] = None,
     ) -> pd.DataFrame:
         """Parse all PDB sequence records.
 
@@ -731,7 +692,7 @@ class PDBManager:
 
         df = pd.DataFrame.from_records(records)
         df["n_chains"] = df.groupby("pdb")["pdb"].transform("count")
-        df["ligands"] = df.pdb.map(self._parse_ligand_map())
+        df["ligands"] = df.pdb.str.upper().map(self._parse_ligand_map())
         df["ligands"] = df["ligands"].fillna("").apply(list)
         df["source"] = df.pdb.map(self._parse_source_map())
         df["resolution"] = df.pdb.map(self._parse_resolution())
@@ -987,32 +948,24 @@ class PDBManager:
 
         if comparison == "equal":
             df = (
-                splits_df[
-                    splits_df.groupby("pdb")["pdb"].transform("size") == length
-                ]
+                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") == length]
                 if compare_pdb_groups
                 else splits_df[splits_df.length == length]
             )
         elif comparison == "less":
             df = (
-                splits_df[
-                    splits_df.groupby("pdb")["pdb"].transform("size") < length
-                ]
+                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") < length]
                 if compare_pdb_groups
                 else splits_df[splits_df.length < length]
             )
         elif comparison == "greater":
             df = (
-                splits_df[
-                    splits_df.groupby("pdb")["pdb"].transform("size") > length
-                ]
+                splits_df[splits_df.groupby("pdb")["pdb"].transform("size") > length]
                 if compare_pdb_groups
                 else splits_df[splits_df.length > length]
             )
         else:
-            raise ValueError(
-                "Comparison must be one of 'equal', 'less', or 'greater'."
-            )
+            raise ValueError("Comparison must be one of 'equal', 'less', or 'greater'.")
 
         if update:
             self.df = df
@@ -1121,9 +1074,7 @@ class PDBManager:
         elif comparison == "greater":
             df = splits_df.loc[splits_df.n_chains >= oligomer]
         else:
-            raise ValueError(
-                "Comparison must be one of 'equal', 'less', or 'greater'."
-            )
+            raise ValueError("Comparison must be one of 'equal', 'less', or 'greater'.")
         if update:
             self.df = df
         return df
@@ -1447,8 +1398,8 @@ class PDBManager:
         :return: Dictionary of DataFrame splits.
         :rtype: Dict[str, pd.DataFrame]
         """
-        assert len(splits) == len(
-            split_ratios
+        assert (
+            len(splits) == len(split_ratios)
         ), f"Number of splits ({len(splits)}) must match number of split ratios ({len(split_ratios)})"
         assert (
             sum(split_ratios) == 1
@@ -1463,9 +1414,7 @@ class PDBManager:
             split_sizes[assign_leftover_rows_to_split_n] += num_remaining_rows
 
         # Without replacement, randomly shuffle rows within the input DataFrame
-        df_sampled = df.sample(
-            frac=1.0, replace=False, random_state=random_state
-        )
+        df_sampled = df.sample(frac=1.0, replace=False, random_state=random_state)
 
         # Split DataFrames
         start_idx = 0
@@ -1489,9 +1438,7 @@ class PDBManager:
         df_split_sizes = " ".join(
             [str(df_splits[split].shape[0]) for split in df_splits]
         )
-        log.info(
-            f"Proportionally-derived dataset splits of sizes: {df_split_sizes}"
-        )
+        log.info(f"Proportionally-derived dataset splits of sizes: {df_split_sizes}")
 
         return df_splits
 
@@ -1626,9 +1573,7 @@ class PDBManager:
         # Build name of FASTA and cluster files
         if cluster_fname is None:
             fasta_fname = "pdb.fasta"
-            cluster_fname = (
-                f"pdb_cluster_rep_seq_id_{min_seq_id}_c_{coverage}.fasta"
-            )
+            cluster_fname = f"pdb_cluster_rep_seq_id_{min_seq_id}_c_{coverage}.fasta"
 
         # Do clustering if overwriting or no clusters were found
         if not os.path.exists(self.root_dir / cluster_fname) or overwrite:
@@ -1642,9 +1587,7 @@ class PDBManager:
             # Create clusters
             log.info("Creating clusters...")
             # Write selection to FASTA
-            log.info(
-                f"Writing current selection ({len(self.df)} chains) to FASTA..."
-            )
+            log.info(f"Writing current selection ({len(self.df)} chains) to FASTA...")
             self.to_fasta(str(self.root_dir / fasta_fname))
             if not is_tool("mmseqs"):
                 log.error(
@@ -1655,9 +1598,7 @@ class PDBManager:
                 cmd = f"mmseqs easy-cluster {str(self.root_dir / fasta_fname)} pdb_cluster tmp --min-seq-id {min_seq_id} -c {coverage} --cov-mode 1"
                 log.info(f"Clustering with: {cmd}")
                 subprocess.run(cmd.split())
-                os.rename(
-                    "pdb_cluster_rep_seq.fasta", self.root_dir / cluster_fname
-                )
+                os.rename("pdb_cluster_rep_seq.fasta", self.root_dir / cluster_fname)
                 log.info("Done clustering!")
         # Otherwise, read from disk
         elif os.path.exists(self.root_dir / cluster_fname):
@@ -1694,8 +1635,8 @@ class PDBManager:
         :return: Dictionary of DataFrame splits.
         :rtype: Dict[str, pd.DataFrame]
         """
-        assert len(splits) == len(
-            split_time_frames
+        assert (
+            len(splits) == len(split_time_frames)
         ), f"Number of splits ({len(splits)}) must match number of time frames ({len(split_time_frames)})."
         assert self._frames_are_sequential(
             split_time_frames
@@ -1729,18 +1670,14 @@ class PDBManager:
             len(all_splits_df) == len(df) - num_remaining_rows
         ), "Number of rows changed during split operations."
         assert (
-            len(
-                all_splits_df.drop(self.list_columns, axis=1).drop_duplicates()
-            )
+            len(all_splits_df.drop(self.list_columns, axis=1).drop_duplicates())
             == len(df) - num_remaining_rows
         ), "Duplicate rows found in splits."
 
         df_split_sizes = " ".join(
             [str(df_splits[split].shape[0]) for split in df_splits]
         )
-        log.info(
-            f"Deposition date-derived dataset splits of sizes: {df_split_sizes}"
-        )
+        log.info(f"Deposition date-derived dataset splits of sizes: {df_split_sizes}")
 
         return df_splits
 
@@ -1762,9 +1699,7 @@ class PDBManager:
         :rtype: Dict[str, pd.DataFrame]
         """
         split_time_frames_provided = self.split_time_frames is not None
-        assert (
-            split_time_frames_provided
-        ), "Split time frames must be provided."
+        assert split_time_frames_provided, "Split time frames must be provided."
 
         # Split sequences
         time_frames = " ".join([str(f) for f in self.split_time_frames])
@@ -1807,18 +1742,12 @@ class PDBManager:
         :rtype: Union[pd.DataFrame, Dict[str, pd.DataFrame]]
         """
         # Drop missing deposition dates
-        df = self.df.dropna().loc[
-            self.df.deposition_date < max_deposition_date
-        ]
+        df = self.df.dropna().loc[self.df.deposition_date < max_deposition_date]
         if update:
             self.df = df
 
         # Split sequences
-        return (
-            self.split_by_deposition_date(df, update)
-            if self.splits_provided
-            else df
-        )
+        return self.split_by_deposition_date(df, update) if self.splits_provided else df
 
     def reset(self) -> pd.DataFrame:
         """Reset the dataset to the original DataFrame source.
@@ -1832,7 +1761,7 @@ class PDBManager:
     def download_pdbs(
         self,
         out_dir: str = ".",
-        format: str = "pdb",
+        format: Literal["pdb", "mmtf", "mmcif", "cif", "bcif"] = "pdb",
         splits: Optional[List[str]] = None,
         overwrite: bool = False,
         max_workers: int = 8,
@@ -1854,9 +1783,7 @@ class PDBManager:
         :param chunksize: Chunk size for each worker, defaults to ``32``.
         :type chunksize: int, optional
         """
-        log.info(
-            f"Downloading {len(self.get_unique_pdbs(splits))} PDB files..."
-        )
+        log.info(f"Downloading {len(self.get_unique_pdbs(splits))} PDB files...")
         download_pdb_multiprocessing(
             self.get_unique_pdbs(splits),
             out_dir,
@@ -1900,33 +1827,23 @@ class PDBManager:
 
         # Check we have all source PDB files
         downloaded = os.listdir(self.pdb_dir)
-        downloaded = [
-            f for f in downloaded if f.endswith(f".{self.structure_format}")
-        ]
+        downloaded = [f for f in downloaded if f.endswith(f".{self.structure_format}")]
 
         to_download = [
-            k
-            for k in df.keys()
-            if f"{k}.{self.structure_format}" not in downloaded
+            k for k in df.keys() if f"{k}.{self.structure_format}" not in downloaded
         ]
         if len(to_download) > 0:
             log.info(f"Downloading {len(to_download)} PDB files...")
-            download_pdb_multiprocessing(
-                to_download, self.pdb_dir, overwrite=True
-            )
+            download_pdb_multiprocessing(to_download, self.pdb_dir, overwrite=True)
             log.info("Done downloading PDB files")
 
         # Iterate over dictionary and write chains to separate files
         log.info("Extracting chains...")
         paths = []
         for k, v in tqdm(df.items()):
-            in_file = os.path.join(
-                self.pdb_dir, f"{k}.{self.structure_format}"
-            )
+            in_file = os.path.join(self.pdb_dir, f"{k}.{self.structure_format}")
             paths.append(
-                extract_chains_to_file(
-                    in_file, v, out_dir=self.pdb_dir, models=models
-                )
+                extract_chains_to_file(in_file, v, out_dir=self.pdb_dir, models=models)
             )
         log.info("Done extracting chains")
 
@@ -1958,9 +1875,7 @@ class PDBManager:
         elif ids == "pdb":
             return splits_df.loc[splits_df.pdb.isin(seq_ids)]
         else:
-            raise ValueError(
-                "Invalid parameter ids. Must be 'chain' or 'pdb'."
-            )
+            raise ValueError("Invalid parameter ids. Must be 'chain' or 'pdb'.")
 
     def to_chain_sequence_mapping_dict(
         self, splits: Optional[List[str]]
@@ -1976,9 +1891,7 @@ class PDBManager:
         """
         splits_df = self.get_splits(splits)
         self._check_download_availability(splits_df, raise_error=False)
-        return (
-            splits_df[["id", "sequence"]].set_index("id").to_dict()["sequence"]
-        )
+        return splits_df[["id", "sequence"]].set_index("id").to_dict()["sequence"]
 
     def to_fasta(self, filename: str, splits: Optional[List[str]] = None):
         """Write the dataset to a FASTA file (indexed by chain id).
@@ -1989,9 +1902,7 @@ class PDBManager:
             defaults to ``None``.
         :type splits: Optional[List[str]], optional
         """
-        self._check_download_availability(
-            self.get_splits(splits), raise_error=False
-        )
+        self._check_download_availability(self.get_splits(splits), raise_error=False)
         with open(filename, "w") as f:
             for k, v in self.to_chain_sequence_mapping_dict(splits).items():
                 f.write(f">{k}\n")
@@ -2011,9 +1922,7 @@ class PDBManager:
             unavailable PDB files are found in ``df``.
         """
         if not all(df.pdb_file_available):
-            unavailable = df.loc[
-                df.pdb_file_available == False, "pdb"
-            ].to_list()
+            unavailable = df.loc[df.pdb_file_available == False, "pdb"].to_list()
             if raise_error:
                 raise ValueError(
                     f"You are exporting a selection that contains {len(unavailable)} PDB(s) unavailable for download in PDB format: {unavailable}"
@@ -2034,9 +1943,7 @@ class PDBManager:
         """
         splits_df = self.get_splits(splits)
         self._check_download_availability(splits_df, raise_error=False)
-        log.info(
-            f"Writing selection ({len(splits_df)} chains) to CSV file: {fname}"
-        )
+        log.info(f"Writing selection ({len(splits_df)} chains) to CSV file: {fname}")
 
         splits_df.to_csv(fname, index=False)
 
@@ -2077,9 +1984,7 @@ class PDBManager:
         """
         for key in pdb.df:
             if field in pdb.df[key]:
-                filtered_pdb = pdb.df[key][
-                    pdb.df[key][field].isin(field_values)
-                ]
+                filtered_pdb = pdb.df[key][pdb.df[key][field].isin(field_values)]
                 if "ATOM" in key and len(filtered_pdb) == 0:
                     log.warning(
                         f"DataFrame for PDB {pdb_code} does not contain any standard atoms after filtering"
@@ -2153,17 +2058,11 @@ class PDBManager:
                         )
                         continue
                     # work around int-typing bug for `model_id` within version `0.5.0.dev0` of BioPandas -> appears when calling `to_pdb()`
-                    cast_pdb_column_to_type(
-                        pdb, column_name="model_id", type=str
-                    )
+                    cast_pdb_column_to_type(pdb, column_name="model_id", type=str)
                     # select only from chains available in the PDB file
-                    pdb_atom_chains = (
-                        pdb.df[atom_df_name].chain_id.unique().tolist()
-                    )
+                    pdb_atom_chains = pdb.df[atom_df_name].chain_id.unique().tolist()
                     chains = [
-                        chain
-                        for chain in entry_chains
-                        if chain in pdb_atom_chains
+                        chain for chain in entry_chains if chain in pdb_atom_chains
                     ]
                     chains = (
                         chains

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -3,6 +3,7 @@ import math
 import os
 import shutil
 import subprocess
+import tempfile
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
@@ -381,11 +382,13 @@ class PDBManager:
         """
         if not os.path.exists(self.root_dir / self.ligand_map_filename):
             log.info("Generating chemical component to PDB map...")
-            generate_pdb_ligand_mappings(
-                pdb_to_cc_output_file=self.root_dir / self.ligand_map_filename,
-                cc_to_pdb_output_file=self.root_dir / self.ligand_map_filename,
-                generate_cc_extra_file=False,
-            )
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                generate_pdb_ligand_mappings(
+                    pdb_to_cc_output_file=Path(tmp_dir) / "pdb-to-cc.tsv",
+                    cc_to_pdb_output_file=self.root_dir
+                    / self.ligand_map_filename,
+                    generate_cc_extra_file=False,
+                )
 
     def _download_source_map(self):
         """Download source map from

--- a/graphein/ml/datasets/pdb_data.py
+++ b/graphein/ml/datasets/pdb_data.py
@@ -382,9 +382,10 @@ class PDBManager:
         """
         if not os.path.exists(self.root_dir / self.ligand_map_filename):
             log.info("Generating chemical component to PDB map...")
-            with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory() as temp_output_dir:
                 generate_pdb_ligand_mappings(
-                    pdb_to_cc_output_file=Path(tmp_dir) / "pdb-to-cc.tsv",
+                    pdb_to_cc_output_file=Path(temp_output_dir)
+                    / "pdb-to-cc.tsv",
                     cc_to_pdb_output_file=self.root_dir
                     / self.ligand_map_filename,
                     generate_cc_extra_file=False,

--- a/graphein/ml/datasets/torch_geometric_dataset.py
+++ b/graphein/ml/datasets/torch_geometric_dataset.py
@@ -130,10 +130,14 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         self.name = name
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
+            [pdb.lower() for pdb in pdb_codes]
+            if pdb_codes is not None
+            else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
+            [up.upper() for up in uniprot_ids]
+            if uniprot_ids is not None
+            else None
         )
 
         self.paths = paths
@@ -149,7 +153,8 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0]
+                    for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -160,7 +165,9 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         elif self.uniprot_ids:
             self.structures = uniprot_ids
         self.af_version = af_version
-        self.bad_pdbs: List[str] = []  # list of pdb codes that failed to download
+        self.bad_pdbs: List[str] = (
+            []
+        )  # list of pdb codes that failed to download
 
         # Labels & Chains
         self.graph_label_map = graph_label_map
@@ -181,7 +188,9 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
             pre_filter=pre_filter,
         )
         self.config.pdb_dir = Path(self.raw_dir)
-        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
+        self.data, self.slices = torch.load(
+            self.processed_paths[0], weights_only=False
+        )
 
     @property
     def raw_file_names(self) -> List[str]:
@@ -239,14 +248,18 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
+        structure_files = [
+            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
+        ]
         for func in self.pdb_transform:
             func(structure_files)
 
     def process(self):
         """Process structures into PyG format and save to disk."""
         # Read data into huge `Data` list.
-        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
+        structure_files = [
+            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
+        ]
 
         # Apply transformations to raw PDB files.
         if self.pdb_transform is not None:
@@ -405,10 +418,14 @@ class ProteinGraphDataset(Dataset):
         :type af_version: int, optional
         """
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
+            [pdb.lower() for pdb in pdb_codes]
+            if pdb_codes is not None
+            else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
+            [up.upper() for up in uniprot_ids]
+            if uniprot_ids is not None
+            else None
         )
         self.paths = paths
         if self.paths is None:
@@ -423,7 +440,8 @@ class ProteinGraphDataset(Dataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0]
+                    for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -504,7 +522,9 @@ class ProteinGraphDataset(Dataset):
             assert len(
                 {
                     f"{pdb}_{chain}"
-                    for pdb, chain in zip(self.structures, self.chain_selection_map)
+                    for pdb, chain in zip(
+                        self.structures, self.chain_selection_map
+                    )
                 }
             ) == len(self.structures), "Duplicate protein/chain combinations"
 
@@ -553,7 +573,9 @@ class ProteinGraphDataset(Dataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
+        structure_files = [
+            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
+        ]
         for func in self.pdb_transform:
             func(structure_files)
 
@@ -576,13 +598,17 @@ class ProteinGraphDataset(Dataset):
                 yield l[i : i + n]
 
         # chunks = list(divide_chunks(self.structures, chunk_size))
-        chunks: List[int] = list(divide_chunks(list(self.examples.keys()), chunk_size))
+        chunks: List[int] = list(
+            divide_chunks(list(self.examples.keys()), chunk_size)
+        )
 
         for chunk in tqdm(chunks):
             pdbs = [self.examples[idx] for idx in chunk]
             # Get chain selections
             if self.chain_selection_map is not None:
-                chain_selections = [self.chain_selection_map[idx] for idx in chunk]
+                chain_selections = [
+                    self.chain_selection_map[idx] for idx in chunk
+                ]
             else:
                 chain_selections = ["all"] * len(chunk)
 
@@ -658,7 +684,9 @@ class ProteinGraphDataset(Dataset):
 
 
 class ProteinGraphListDataset(InMemoryDataset):
-    def __init__(self, root: str, data_list: List[Data], name: str, transform=None):
+    def __init__(
+        self, root: str, data_list: List[Data], name: str, transform=None
+    ):
         """Creates a dataset from a list of PyTorch Geometric Data objects.
 
         :param root: Root directory where the dataset is stored.
@@ -677,7 +705,9 @@ class ProteinGraphListDataset(InMemoryDataset):
         self.data_list = data_list
         self.name = name
         super().__init__(root, transform)
-        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
+        self.data, self.slices = torch.load(
+            self.processed_paths[0], weights_only=False
+        )
 
     @property
     def processed_file_names(self):

--- a/graphein/ml/datasets/torch_geometric_dataset.py
+++ b/graphein/ml/datasets/torch_geometric_dataset.py
@@ -130,14 +130,10 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         self.name = name
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes]
-            if pdb_codes is not None
-            else None
+            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids]
-            if uniprot_ids is not None
-            else None
+            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
         )
 
         self.paths = paths
@@ -153,8 +149,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0]
-                    for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -165,9 +160,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         elif self.uniprot_ids:
             self.structures = uniprot_ids
         self.af_version = af_version
-        self.bad_pdbs: List[str] = (
-            []
-        )  # list of pdb codes that failed to download
+        self.bad_pdbs: List[str] = []  # list of pdb codes that failed to download
 
         # Labels & Chains
         self.graph_label_map = graph_label_map
@@ -188,9 +181,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
             pre_filter=pre_filter,
         )
         self.config.pdb_dir = Path(self.raw_dir)
-        self.data, self.slices = torch.load(
-            self.processed_paths[0], weights_only=False
-        )
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def raw_file_names(self) -> List[str]:
@@ -248,18 +239,14 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
         for func in self.pdb_transform:
             func(structure_files)
 
     def process(self):
         """Process structures into PyG format and save to disk."""
         # Read data into huge `Data` list.
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
 
         # Apply transformations to raw PDB files.
         if self.pdb_transform is not None:
@@ -418,14 +405,10 @@ class ProteinGraphDataset(Dataset):
         :type af_version: int, optional
         """
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes]
-            if pdb_codes is not None
-            else None
+            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids]
-            if uniprot_ids is not None
-            else None
+            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
         )
         self.paths = paths
         if self.paths is None:
@@ -440,8 +423,7 @@ class ProteinGraphDataset(Dataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0]
-                    for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -522,9 +504,7 @@ class ProteinGraphDataset(Dataset):
             assert len(
                 {
                     f"{pdb}_{chain}"
-                    for pdb, chain in zip(
-                        self.structures, self.chain_selection_map
-                    )
+                    for pdb, chain in zip(self.structures, self.chain_selection_map)
                 }
             ) == len(self.structures), "Duplicate protein/chain combinations"
 
@@ -573,9 +553,7 @@ class ProteinGraphDataset(Dataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
         for func in self.pdb_transform:
             func(structure_files)
 
@@ -590,7 +568,6 @@ class ProteinGraphDataset(Dataset):
         if self.pdb_transform:
             self.transform_pdbs()
 
-        idx = 0
         # Chunk dataset for parallel processing
         chunk_size = 128
 
@@ -599,17 +576,13 @@ class ProteinGraphDataset(Dataset):
                 yield l[i : i + n]
 
         # chunks = list(divide_chunks(self.structures, chunk_size))
-        chunks: List[int] = list(
-            divide_chunks(list(self.examples.keys()), chunk_size)
-        )
+        chunks: List[int] = list(divide_chunks(list(self.examples.keys()), chunk_size))
 
         for chunk in tqdm(chunks):
             pdbs = [self.examples[idx] for idx in chunk]
             # Get chain selections
             if self.chain_selection_map is not None:
-                chain_selections = [
-                    self.chain_selection_map[idx] for idx in chunk
-                ]
+                chain_selections = [self.chain_selection_map[idx] for idx in chunk]
             else:
                 chain_selections = ["all"] * len(chunk)
 
@@ -685,9 +658,7 @@ class ProteinGraphDataset(Dataset):
 
 
 class ProteinGraphListDataset(InMemoryDataset):
-    def __init__(
-        self, root: str, data_list: List[Data], name: str, transform=None
-    ):
+    def __init__(self, root: str, data_list: List[Data], name: str, transform=None):
         """Creates a dataset from a list of PyTorch Geometric Data objects.
 
         :param root: Root directory where the dataset is stored.
@@ -706,9 +677,7 @@ class ProteinGraphListDataset(InMemoryDataset):
         self.data_list = data_list
         self.name = name
         super().__init__(root, transform)
-        self.data, self.slices = torch.load(
-            self.processed_paths[0], weights_only=False
-        )
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def processed_file_names(self):

--- a/graphein/ml/datasets/torch_geometric_dataset.py
+++ b/graphein/ml/datasets/torch_geometric_dataset.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, Generator, List, Optional
 
 import networkx as nx
 from loguru import logger as log
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from graphein.ml.conversion import GraphFormatConvertor
 from graphein.protein.config import ProteinGraphConfig
@@ -130,14 +130,10 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         self.name = name
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes]
-            if pdb_codes is not None
-            else None
+            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids]
-            if uniprot_ids is not None
-            else None
+            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
         )
 
         self.paths = paths
@@ -153,8 +149,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0]
-                    for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -165,9 +160,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         elif self.uniprot_ids:
             self.structures = uniprot_ids
         self.af_version = af_version
-        self.bad_pdbs: List[str] = (
-            []
-        )  # list of pdb codes that failed to download
+        self.bad_pdbs: List[str] = []  # list of pdb codes that failed to download
 
         # Labels & Chains
         self.graph_label_map = graph_label_map
@@ -188,9 +181,7 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
             pre_filter=pre_filter,
         )
         self.config.pdb_dir = Path(self.raw_dir)
-        self.data, self.slices = torch.load(
-            self.processed_paths[0], weights_only=False
-        )
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def raw_file_names(self) -> List[str]:
@@ -248,18 +239,14 @@ class InMemoryProteinGraphDataset(InMemoryDataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
         for func in self.pdb_transform:
             func(structure_files)
 
     def process(self):
         """Process structures into PyG format and save to disk."""
         # Read data into huge `Data` list.
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
 
         # Apply transformations to raw PDB files.
         if self.pdb_transform is not None:
@@ -418,14 +405,10 @@ class ProteinGraphDataset(Dataset):
         :type af_version: int, optional
         """
         self.pdb_codes = (
-            [pdb.lower() for pdb in pdb_codes]
-            if pdb_codes is not None
-            else None
+            [pdb.lower() for pdb in pdb_codes] if pdb_codes is not None else None
         )
         self.uniprot_ids = (
-            [up.upper() for up in uniprot_ids]
-            if uniprot_ids is not None
-            else None
+            [up.upper() for up in uniprot_ids] if uniprot_ids is not None else None
         )
         self.paths = paths
         if self.paths is None:
@@ -440,8 +423,7 @@ class ProteinGraphDataset(Dataset):
         else:
             if isinstance(self.paths, list):
                 self.structures = [
-                    os.path.splitext(os.path.split(path)[-1])[0]
-                    for path in self.paths
+                    os.path.splitext(os.path.split(path)[-1])[0] for path in self.paths
                 ]
                 self.path, _ = os.path.split(self.paths[0])
 
@@ -522,9 +504,7 @@ class ProteinGraphDataset(Dataset):
             assert len(
                 {
                     f"{pdb}_{chain}"
-                    for pdb, chain in zip(
-                        self.structures, self.chain_selection_map
-                    )
+                    for pdb, chain in zip(self.structures, self.chain_selection_map)
                 }
             ) == len(self.structures), "Duplicate protein/chain combinations"
 
@@ -573,9 +553,7 @@ class ProteinGraphDataset(Dataset):
         """
         Performs pre-processing of PDB structures before constructing graphs.
         """
-        structure_files = [
-            f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures
-        ]
+        structure_files = [f"{self.raw_dir}/{pdb}.pdb" for pdb in self.structures]
         for func in self.pdb_transform:
             func(structure_files)
 
@@ -598,17 +576,13 @@ class ProteinGraphDataset(Dataset):
                 yield l[i : i + n]
 
         # chunks = list(divide_chunks(self.structures, chunk_size))
-        chunks: List[int] = list(
-            divide_chunks(list(self.examples.keys()), chunk_size)
-        )
+        chunks: List[int] = list(divide_chunks(list(self.examples.keys()), chunk_size))
 
         for chunk in tqdm(chunks):
             pdbs = [self.examples[idx] for idx in chunk]
             # Get chain selections
             if self.chain_selection_map is not None:
-                chain_selections = [
-                    self.chain_selection_map[idx] for idx in chunk
-                ]
+                chain_selections = [self.chain_selection_map[idx] for idx in chunk]
             else:
                 chain_selections = ["all"] * len(chunk)
 
@@ -684,9 +658,7 @@ class ProteinGraphDataset(Dataset):
 
 
 class ProteinGraphListDataset(InMemoryDataset):
-    def __init__(
-        self, root: str, data_list: List[Data], name: str, transform=None
-    ):
+    def __init__(self, root: str, data_list: List[Data], name: str, transform=None):
         """Creates a dataset from a list of PyTorch Geometric Data objects.
 
         :param root: Root directory where the dataset is stored.
@@ -705,9 +677,7 @@ class ProteinGraphListDataset(InMemoryDataset):
         self.data_list = data_list
         self.name = name
         super().__init__(root, transform)
-        self.data, self.slices = torch.load(
-            self.processed_paths[0], weights_only=False
-        )
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def processed_file_names(self):

--- a/graphein/ml/datasets/utils.py
+++ b/graphein/ml/datasets/utils.py
@@ -99,7 +99,10 @@ def fetch_all_chem_comp_ids(chem_comp_types_to_include: list):
     entry_chem_comp_results = result.get("data", {}).get("entries", [])
 
     n_entries = len(entry_chem_comp_results)
-    logger.info("Fetched chemical component data for {n_entries} entries", n_entries=n_entries)
+    logger.info(
+        "Fetched chemical component data for {n_entries} entries",
+        n_entries=n_entries,
+    )
 
     return entry_chem_comp_results
 
@@ -137,8 +140,12 @@ def process_chem_comp_results_and_write_to_file(
                 if nonpolymer_comp:
                     chem_id = nonpolymer_comp.get("nonpolymer_comp_id")
                     if chem_id:
-                        pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
-                        chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+                        pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(
+                            chem_id
+                        )
+                        chem_comp_to_pdb_map.setdefault(chem_id, set()).add(
+                            pdb_id
+                        )
 
         # --- 2. Branched Entities ---
         # Includes things like monomers in saccharides
@@ -154,8 +161,12 @@ def process_chem_comp_results_and_write_to_file(
                     )
                     if chem_comp_monomers:
                         for chem_id in chem_comp_monomers:
-                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
-                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(
+                                chem_id
+                            )
+                            chem_comp_to_pdb_map.setdefault(
+                                chem_id, set()
+                            ).add(pdb_id)
 
         # --- 3. Polymer Entities ---
         polymer_entities = entry.get("polymer_entities")
@@ -166,21 +177,33 @@ def process_chem_comp_results_and_write_to_file(
                 )
                 if polymer_entity_container_identifiers:
                     # Includes non-standard residues within polymer chains
-                    chem_comp_nstd_monomers = polymer_entity_container_identifiers.get(
-                        "chem_comp_nstd_monomers"
+                    chem_comp_nstd_monomers = (
+                        polymer_entity_container_identifiers.get(
+                            "chem_comp_nstd_monomers"
+                        )
                     )
                     if chem_comp_nstd_monomers:
                         for chem_id in chem_comp_nstd_monomers:
-                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
-                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(
+                                chem_id
+                            )
+                            chem_comp_to_pdb_map.setdefault(
+                                chem_id, set()
+                            ).add(pdb_id)
                     # Includes standard residues within polymer chains
-                    chem_comp_poly_monomers = polymer_entity_container_identifiers.get(
-                        "chem_comp_monomers"
+                    chem_comp_poly_monomers = (
+                        polymer_entity_container_identifiers.get(
+                            "chem_comp_monomers"
+                        )
                     )
                     if chem_comp_poly_monomers:
                         for chem_id in chem_comp_poly_monomers:
-                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
-                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(
+                                chem_id
+                            )
+                            chem_comp_to_pdb_map.setdefault(
+                                chem_id, set()
+                            ).add(pdb_id)
 
     # Write the final PDB -> CC mapping to a TSV file
     with open(pdb_to_cc_output_file, "w", encoding="utf-8") as f:
@@ -211,8 +234,15 @@ def process_chem_comp_results_and_write_to_file(
         cc_extra_tuple_list = generate_cc_extra_data(chem_comp_to_pdb_map)
         with open(cc_extras_output_file, "w", encoding="utf-8") as f:
             f.write("id\tcount\tname\tformula\n")
-            for cc_id, cc_occurrence_count, cc_name, cc_formula in cc_extra_tuple_list:
-                f.write(f"{cc_id}\t{cc_occurrence_count}\t{cc_name}\t{cc_formula}\n")
+            for (
+                cc_id,
+                cc_occurrence_count,
+                cc_name,
+                cc_formula,
+            ) in cc_extra_tuple_list:
+                f.write(
+                    f"{cc_id}\t{cc_occurrence_count}\t{cc_name}\t{cc_formula}\n"
+                )
         logger.info(
             "CC extras written to '{path}' for {n_cc} components",
             path=cc_extras_output_file,
@@ -250,7 +280,9 @@ def generate_cc_extra_data(chem_comp_to_pdb_map):
         cc_extra_tup = (cc_id, cc_occurrence_count, cc_name, cc_formula)
         cc_extra_tuples.append(cc_extra_tup)
 
-    cc_extra_tuples_sorted = sorted(cc_extra_tuples, key=lambda x: x[1], reverse=True)
+    cc_extra_tuples_sorted = sorted(
+        cc_extra_tuples, key=lambda x: x[1], reverse=True
+    )
     return cc_extra_tuples_sorted
 
 
@@ -289,7 +321,8 @@ def generate_pdb_ligand_mappings(
     # Map high-level chem component type labels to the underlying RCSB Data API
     # return fields.
     chem_comp_types_to_include = [
-        CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS[cc_type] for cc_type in chem_comp_types
+        CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS[cc_type]
+        for cc_type in chem_comp_types
     ]
 
     # Configure the Data API client

--- a/graphein/ml/datasets/utils.py
+++ b/graphein/ml/datasets/utils.py
@@ -1,0 +1,375 @@
+"""
+Modified from: https://github.com/rcsb/rcsb-training-resources/blob/master/example-use-cases/pdb-ligand-composition/generate_pdb_ligand_mappings.py
+This script generates two mapping files (output as TSV files):
+
+    1. A mapping between all PDB structures and the ligands present in each structure
+       (`pdb-to-cc.tsv`)
+    2. A mapping between all ligands in the PDB and the corresponding list of PDB
+       structures in which they are present (`cc-to-pdb.tsv`)
+
+The following types of ligands (or "chemical components") can be included in the mappings:
+
+    - Those that exist as a nonpolymer entity (e.g., a non-covalently bound ATP ligand)
+    - Those that exist as a monomer within a branched polymer entity (e.g., a subunit in a carbohydrate)
+    - Those that exist as a non-standard amino acid monomer within a polymer entity
+    - Those that exist as a standard amino acid monomer within a polymer entity
+
+By default, the first three are included. You can control this using the '--chem_comp_types' argument.
+
+Additionally, this script can generate a file with the occurrence count of chemical components
+along with its name and formula (`cc-counts-extra.tsv`), using the '--generate_cc_extra_file' flag.
+
+
+Requirements:
+    pip install "rcsb-api>=1.4.0"
+
+Usage:
+    # Get usage details
+        python3 generate_pdb_ligand_mappings.py --help
+
+    # Generate the PDB->CC and CC->PDB files
+        python3 generate_pdb_ligand_mappings.py
+
+    # Generate the PDB->CC and CC->PDB files, plus the CC counts file
+        python3 generate_pdb_ligand_mappings.py --generate_cc_extra_file
+
+    # Generate the PDB->CC and CC->PDB files, omitting non-standard amino acids
+        python3 generate_pdb_ligand_mappings.py --chem_comp_types nonpolymer branched
+
+    # Generate the PDB->CC and CC->PDB files, including standard amino acids occurring within a polymer chain
+        python3 generate_pdb_ligand_mappings.py --chem_comp_types nonpolymer branched polymer_nstd polymer_std
+
+Output (can customize name using corresponding CLI arguments):
+    pdb-to-cc.tsv
+        # Format:  <pdb_id1>        <chem_comp_id_1>  <chem_comp_id_2>  ...
+
+    cc-to-pdb.tsv
+        # Format:  <chem_comp_id>   <pdb_id_1>  <pdb_id_2>  ...
+
+    cc-counts-extra.tsv
+        # Format:  <chem_comp_id>   <count>  <name>  <formula>
+"""
+
+import argparse
+import time
+
+from loguru import logger
+from rcsbapi.config import config
+from rcsbapi.data import ALL_STRUCTURES
+from rcsbapi.data import DataQuery as Query
+
+# Public constants for use in the Python API
+ALLOWED_CHEM_COMP_TYPES = (
+    "nonpolymer",
+    "branched",
+    "polymer_nstd",
+    "polymer_std",
+)
+
+DEFAULT_CHEM_COMP_TYPES = ("nonpolymer", "branched", "polymer_nstd")
+
+CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS = {
+    "nonpolymer": "nonpolymer_entities.rcsb_nonpolymer_entity_container_identifiers.nonpolymer_comp_id",  # Ligands in nonpolymer entities
+    "branched": "branched_entities.rcsb_branched_entity_container_identifiers.chem_comp_monomers",  # Monomers in branched entities
+    "polymer_nstd": "polymer_entities.rcsb_polymer_entity_container_identifiers.chem_comp_nstd_monomers",  # Non-standard monomers in polymer chains
+    "polymer_std": "polymer_entities.rcsb_polymer_entity_container_identifiers.chem_comp_monomers",  # Standard monomers in polymer chains
+}
+
+
+def fetch_all_chem_comp_ids(chem_comp_types_to_include: list):
+    """Fetch the chemical component and PDB mapping data from RCSB.org using the Data API"""
+
+    logger.info(
+        "Fetching chemical component data for {n_types} chem component field(s): {types}",
+        n_types=len(chem_comp_types_to_include),
+        types=chem_comp_types_to_include,
+    )
+
+    # Initialize the data query to retrieve relevant chemical component data
+    query = Query(
+        input_type="entries",  # Query all structure entries
+        input_ids=ALL_STRUCTURES,  # Constant representing all known structures
+        return_data_list=["rcsb_id"] + chem_comp_types_to_include,
+    )
+
+    # Execute the query with a progress bar
+    result = query.exec(progress_bar=True)
+
+    # Extract list of returned structure entries
+    entry_chem_comp_results = result.get("data", {}).get("entries", [])
+
+    n_entries = len(entry_chem_comp_results)
+    logger.info("Fetched chemical component data for {n_entries} entries", n_entries=n_entries)
+
+    return entry_chem_comp_results
+
+
+def process_chem_comp_results_and_write_to_file(
+    entry_chem_comp_results: dict,
+    pdb_to_cc_output_file: str,
+    cc_to_pdb_output_file: str,
+    cc_extras_output_file: str,
+    generate_cc_extra_file: bool,
+):
+    """Process the fetched Data API data to create the mapping between chemical component IDs and PDB IDs"""
+
+    logger.info(
+        "Processing {n_entries} entries into ligand mapping files",
+        n_entries=len(entry_chem_comp_results),
+    )
+
+    # Dictionary to collect mapping from chem_comp_id to a set of PDB IDs
+    pdb_to_chem_comp_map = {}
+    chem_comp_to_pdb_map = {}
+
+    # Iterate over all returned entries
+    for entry in entry_chem_comp_results:
+        pdb_id = entry.get("rcsb_id")
+
+        # --- 1. Nonpolymer Entities ---
+        # Small molecule ligands
+        nonpolymer_entities = entry.get("nonpolymer_entities")
+        if nonpolymer_entities:
+            for nonpolymer in nonpolymer_entities:
+                nonpolymer_comp = nonpolymer.get(
+                    "rcsb_nonpolymer_entity_container_identifiers"
+                )
+                if nonpolymer_comp:
+                    chem_id = nonpolymer_comp.get("nonpolymer_comp_id")
+                    if chem_id:
+                        pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
+                        chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+
+        # --- 2. Branched Entities ---
+        # Includes things like monomers in saccharides
+        branched_entities = entry.get("branched_entities")
+        if branched_entities:
+            for branched in branched_entities:
+                branched_container_identifiers = branched.get(
+                    "rcsb_branched_entity_container_identifiers"
+                )
+                if branched_container_identifiers:
+                    chem_comp_monomers = branched_container_identifiers.get(
+                        "chem_comp_monomers"
+                    )
+                    if chem_comp_monomers:
+                        for chem_id in chem_comp_monomers:
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
+                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+
+        # --- 3. Polymer Entities ---
+        polymer_entities = entry.get("polymer_entities")
+        if polymer_entities:
+            for polymer in polymer_entities:
+                polymer_entity_container_identifiers = polymer.get(
+                    "rcsb_polymer_entity_container_identifiers"
+                )
+                if polymer_entity_container_identifiers:
+                    # Includes non-standard residues within polymer chains
+                    chem_comp_nstd_monomers = polymer_entity_container_identifiers.get(
+                        "chem_comp_nstd_monomers"
+                    )
+                    if chem_comp_nstd_monomers:
+                        for chem_id in chem_comp_nstd_monomers:
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
+                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+                    # Includes standard residues within polymer chains
+                    chem_comp_poly_monomers = polymer_entity_container_identifiers.get(
+                        "chem_comp_monomers"
+                    )
+                    if chem_comp_poly_monomers:
+                        for chem_id in chem_comp_poly_monomers:
+                            pdb_to_chem_comp_map.setdefault(pdb_id, set()).add(chem_id)
+                            chem_comp_to_pdb_map.setdefault(chem_id, set()).add(pdb_id)
+
+    # Write the final PDB -> CC mapping to a TSV file
+    with open(pdb_to_cc_output_file, "w", encoding="utf-8") as f:
+        for pdbid, ccids in pdb_to_chem_comp_map.items():
+            f.write(f"{pdbid}\t{' '.join(sorted(ccids))}\n")
+    logger.info(
+        "PDB → CC mapping written to '{path}' for {n_pdb} PDB IDs",
+        path=pdb_to_cc_output_file,
+        n_pdb=len(pdb_to_chem_comp_map),
+    )
+
+    # Write the final CC -> PDB mapping to a TSV file
+    with open(cc_to_pdb_output_file, "w", encoding="utf-8") as f:
+        for ccid, pdb_ids in chem_comp_to_pdb_map.items():
+            f.write(f"{ccid}\t{' '.join(sorted(pdb_ids))}\n")
+    logger.info(
+        "CC → PDB mapping written to '{path}' for {n_cc} chemical components",
+        path=cc_to_pdb_output_file,
+        n_cc=len(chem_comp_to_pdb_map),
+    )
+
+    # Write the chemical components extra file (if requested)
+    if generate_cc_extra_file:
+        logger.info(
+            "Generating chemical component extras for {n_cc} components",
+            n_cc=len(chem_comp_to_pdb_map),
+        )
+        cc_extra_tuple_list = generate_cc_extra_data(chem_comp_to_pdb_map)
+        with open(cc_extras_output_file, "w", encoding="utf-8") as f:
+            f.write("id\tcount\tname\tformula\n")
+            for cc_id, cc_occurrence_count, cc_name, cc_formula in cc_extra_tuple_list:
+                f.write(f"{cc_id}\t{cc_occurrence_count}\t{cc_name}\t{cc_formula}\n")
+        logger.info(
+            "CC extras written to '{path}' for {n_cc} components",
+            path=cc_extras_output_file,
+            n_cc=len(cc_extra_tuple_list),
+        )
+
+
+def generate_cc_extra_data(chem_comp_to_pdb_map):
+    """Generate the chemical component extra data"""
+    cc_list = list(chem_comp_to_pdb_map.keys())
+    if len(cc_list) == 0:
+        return []
+
+    # Fetch extra chemical component data
+    query = Query(
+        input_type="chem_comps",
+        input_ids=cc_list,
+        return_data_list=["rcsb_id", "chem_comp.formula", "chem_comp.name"],
+    )
+    cc_result = query.exec(progress_bar=True)
+    chem_comp_results = cc_result.get("data", {}).get("chem_comps", [])
+
+    # Process the results into a list of tuples
+    cc_extra_tuples = []
+    for cc in chem_comp_results:
+        cc_name, cc_formula = None, None
+        cc_id = cc["rcsb_id"]
+        cc_data = cc.get("chem_comp")
+        if cc_data:
+            cc_name = cc_data.get("name")
+            if cc_name:
+                cc_name = cc_name.replace("\n", "")  # strip newline characters
+            cc_formula = cc_data.get("formula")
+        cc_occurrence_count = len(chem_comp_to_pdb_map[cc_id])
+        cc_extra_tup = (cc_id, cc_occurrence_count, cc_name, cc_formula)
+        cc_extra_tuples.append(cc_extra_tup)
+
+    cc_extra_tuples_sorted = sorted(cc_extra_tuples, key=lambda x: x[1], reverse=True)
+    return cc_extra_tuples_sorted
+
+
+def generate_pdb_ligand_mappings(
+    chem_comp_types=None,
+    pdb_to_cc_output_file: str = "pdb-to-cc.tsv",
+    cc_to_pdb_output_file: str = "cc-to-pdb.tsv",
+    cc_extras_output_file: str = "cc-counts-extra.tsv",
+    max_concurrent_api_requests: int = 10,
+    generate_cc_extra_file: bool = False,
+) -> None:
+    """
+    High-level API for generating PDB/ligand mapping files.
+
+    This is the preferred entrypoint when using this module from Python code.
+
+    Parameters
+    ----------
+    chem_comp_types:
+        Iterable of chemical component type labels to include. Must be drawn
+        from ``ALLOWED_CHEM_COMP_TYPES``. If ``None``, uses ``DEFAULT_CHEM_COMP_TYPES``.
+    pdb_to_cc_output_file:
+        Path for the PDB → CC mapping TSV file.
+    cc_to_pdb_output_file:
+        Path for the CC → PDB mapping TSV file.
+    cc_extras_output_file:
+        Path for the CC extras TSV file.
+    max_concurrent_api_requests:
+        Maximum number of concurrent Data API requests.
+    generate_cc_extra_file:
+        If ``True``, also generate the CC extras file.
+    """
+    if chem_comp_types is None:
+        chem_comp_types = DEFAULT_CHEM_COMP_TYPES
+
+    # Map high-level chem component type labels to the underlying RCSB Data API
+    # return fields.
+    chem_comp_types_to_include = [
+        CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS[cc_type] for cc_type in chem_comp_types
+    ]
+
+    # Configure the Data API client
+    config.DATA_API_MAX_CONCURRENT_REQUESTS = max_concurrent_api_requests
+
+    start = time.time()
+    entry_chem_comp_data = fetch_all_chem_comp_ids(chem_comp_types_to_include)
+    process_chem_comp_results_and_write_to_file(
+        entry_chem_comp_data,
+        pdb_to_cc_output_file,
+        cc_to_pdb_output_file,
+        cc_extras_output_file,
+        generate_cc_extra_file,
+    )
+    end = time.time()
+    print(f"Processing completed in {end - start:.2f} seconds.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate mappings between PDB structures and ligands.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    allowed_cc_types = list(ALLOWED_CHEM_COMP_TYPES)
+    cc_type_help_text = (
+        "Chemical component types to include (space separated).\n"
+        "Allowed values:\n"
+        "  nonpolymer   - Ligands as nonpolymer entities (e.g., a non-covalently bound ATP ligand)\n"
+        "  branched     - Monomers in branched entities (e.g., a subunit in a carbohydrate)\n"
+        "  polymer_nstd - Non-standard monomers in polymer chains\n"
+        "  polymer_std  - Standard monomers in polymer chains\n"
+        "Default is %(default)s."
+    )
+    parser.add_argument(
+        "--chem_comp_types",
+        nargs="+",
+        choices=allowed_cc_types,
+        default=["nonpolymer", "branched", "polymer_nstd"],
+        help=cc_type_help_text,
+    )
+    parser.add_argument(
+        "--pdb_to_cc_output_file",
+        default="pdb-to-cc.tsv",
+        help="Mapping between all PDB structures and the ligands present in each structure (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--cc_to_pdb_output_file",
+        default="cc-to-pdb.tsv",
+        help="Mapping between all ligands in the PDB and the corresponding list of PDB structures in which they are present (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--cc_extras_output_file",
+        default="cc-counts-extra.tsv",
+        help="Tabulation of the number of PDB entries containing each chemical component, including name and formula (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--max_concurrent_api_requests",
+        type=int,
+        default=10,
+        help="Maximum number of concurrent Data API requests (default: %(default)s).",
+    )
+
+    parser.add_argument(
+        "--generate_cc_extra_file",
+        action="store_true",
+        default=False,
+        help="Turn on generation of the chemical components extra file (see '--cc_extras_output_file').",
+    )
+
+    args = parser.parse_args()
+
+    generate_pdb_ligand_mappings(
+        chem_comp_types=args.chem_comp_types,
+        pdb_to_cc_output_file=args.pdb_to_cc_output_file,
+        cc_to_pdb_output_file=args.cc_to_pdb_output_file,
+        cc_extras_output_file=args.cc_extras_output_file,
+        max_concurrent_api_requests=args.max_concurrent_api_requests,
+        generate_cc_extra_file=args.generate_cc_extra_file,
+    )

--- a/graphein/ml/datasets/utils.py
+++ b/graphein/ml/datasets/utils.py
@@ -318,6 +318,16 @@ def generate_pdb_ligand_mappings(
     if chem_comp_types is None:
         chem_comp_types = DEFAULT_CHEM_COMP_TYPES
 
+    invalid_chem_comp_types = sorted(
+        set(chem_comp_types) - set(ALLOWED_CHEM_COMP_TYPES)
+    )
+    if invalid_chem_comp_types:
+        raise ValueError(
+            "Invalid chem_comp_types: "
+            f"{invalid_chem_comp_types}. Allowed values are: "
+            f"{ALLOWED_CHEM_COMP_TYPES}."
+        )
+
     # Map high-level chem component type labels to the underlying RCSB Data API
     # return fields.
     chem_comp_types_to_include = [

--- a/graphein/ml/datasets/utils.py
+++ b/graphein/ml/datasets/utils.py
@@ -338,7 +338,7 @@ def generate_pdb_ligand_mappings(
         generate_cc_extra_file,
     )
     end = time.time()
-    print(f"Processing completed in {end - start:.2f} seconds.")
+    logger.info(f"Processing completed in {end - start:.2f} seconds.")
 
 
 if __name__ == "__main__":

--- a/graphein/ppi/parse_biogrid.py
+++ b/graphein/ppi/parse_biogrid.py
@@ -168,7 +168,9 @@ def parse_BIOGRID(
 
         return df
 
-    return make_call(request_url=request_url, params=params, start=0, max=params["max"])
+    return make_call(
+        request_url=request_url, params=params, start=0, max=params["max"]
+    )
 
 
 def filter_BIOGRID(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
@@ -207,7 +209,9 @@ def standardise_BIOGRID(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame({"p1": [], "p2": [], "source": []})
 
     # Rename & delete columns
-    df = df.rename(columns={"OFFICIAL_SYMBOL_A": "p1", "OFFICIAL_SYMBOL_B": "p2"})
+    df = df.rename(
+        columns={"OFFICIAL_SYMBOL_A": "p1", "OFFICIAL_SYMBOL_B": "p2"}
+    )
     df = df[["p1", "p2"]]
 
     # Add source column
@@ -236,7 +240,9 @@ def BIOGRID_df(
     :return: Standardised DataFrame with BIOGRID interactions.
     :rtype: pd.DataFrame
     """
-    df = parse_BIOGRID(protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs)
+    df = parse_BIOGRID(
+        protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs
+    )
     df = filter_BIOGRID(df, **kwargs)
     df = standardise_BIOGRID(df)
     return df

--- a/graphein/ppi/parse_biogrid.py
+++ b/graphein/ppi/parse_biogrid.py
@@ -6,7 +6,7 @@
 # License: MIT
 # Project Website: https://github.com/a-r-j/graphein
 # Code Repository: https://github.com/a-r-j/graphein
-
+import io
 from typing import Dict, List, Union
 
 import pandas as pd
@@ -158,7 +158,7 @@ def parse_BIOGRID(
         """
         params["start"] = start
         response = requests.post(request_url, data=params)
-        df = pd.read_json(response.text.strip()).transpose()
+        df = pd.read_json(io.StringIO(response.text.strip())).transpose()
 
         # Maximum number of results is limited to 10k. Paginate to
         # retrieve everything
@@ -168,9 +168,7 @@ def parse_BIOGRID(
 
         return df
 
-    return make_call(
-        request_url=request_url, params=params, start=0, max=params["max"]
-    )
+    return make_call(request_url=request_url, params=params, start=0, max=params["max"])
 
 
 def filter_BIOGRID(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
@@ -209,9 +207,7 @@ def standardise_BIOGRID(df: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame({"p1": [], "p2": [], "source": []})
 
     # Rename & delete columns
-    df = df.rename(
-        columns={"OFFICIAL_SYMBOL_A": "p1", "OFFICIAL_SYMBOL_B": "p2"}
-    )
+    df = df.rename(columns={"OFFICIAL_SYMBOL_A": "p1", "OFFICIAL_SYMBOL_B": "p2"})
     df = df[["p1", "p2"]]
 
     # Add source column
@@ -240,9 +236,7 @@ def BIOGRID_df(
     :return: Standardised DataFrame with BIOGRID interactions.
     :rtype: pd.DataFrame
     """
-    df = parse_BIOGRID(
-        protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs
-    )
+    df = parse_BIOGRID(protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs)
     df = filter_BIOGRID(df, **kwargs)
     df = standardise_BIOGRID(df)
     return df

--- a/graphein/ppi/parse_stringdb.py
+++ b/graphein/ppi/parse_stringdb.py
@@ -169,7 +169,9 @@ def STRING_df(
     :return: Standardised DataFrame with STRING interactions
     :rtype: pd.DataFrame
     """
-    df = parse_STRING(protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs)
+    df = parse_STRING(
+        protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs
+    )
     df = filter_STRING(df, **kwargs)
     df = standardise_STRING(df)
 

--- a/graphein/ppi/parse_stringdb.py
+++ b/graphein/ppi/parse_stringdb.py
@@ -7,6 +7,7 @@
 # Project Website: https://github.com/a-r-j/graphein
 # Code Repository: https://github.com/a-r-j/graphein
 
+import io
 from typing import Dict, List, Union
 
 import pandas as pd
@@ -90,7 +91,7 @@ def parse_STRING(
 
     # Call STRING
     response = requests.post(request_url, data=params)
-    return pd.read_json(response.text.strip())
+    return pd.read_json(io.StringIO(response.text.strip()))
 
 
 def filter_STRING(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
@@ -168,9 +169,7 @@ def STRING_df(
     :return: Standardised DataFrame with STRING interactions
     :rtype: pd.DataFrame
     """
-    df = parse_STRING(
-        protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs
-    )
+    df = parse_STRING(protein_list=protein_list, ncbi_taxon_id=ncbi_taxon_id, **kwargs)
     df = filter_STRING(df, **kwargs)
     df = standardise_STRING(df)
 

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -50,6 +50,12 @@ pdb_df_columns = [
     "line_idx",
 ]
 
+PDB_OBSOLETE_URL = "https://files.wwpdb.org/pub/pdb/data/status/obsolete.dat"
+
+ALPHAFOLD_DB_BASE_URL = "https://alphafold.ebi.ac.uk/files/"
+
+ESM_ATLAS_BASE_URL = "https://api.esmatlas.com/foldSequence/v"
+
 
 class ProteinGraphConfigurationError(Exception):
     """
@@ -73,9 +79,7 @@ def get_obsolete_mapping() -> Dict[str, str]:
     """
     obs_dict: Dict[str, str] = {}
 
-    response = urlopen(
-        "https://files.wwpdb.org/pub/pdb/data/status/obsolete.dat"
-    )
+    response = urlopen(PDB_OBSOLETE_URL)
     for line in response:
         entry = line.split()
         if len(entry) == 4:
@@ -87,7 +91,7 @@ def get_obsolete_mapping() -> Dict[str, str]:
     return obs_dict
 
 
-def read_fasta(file_path: str) -> Dict[str, str]:
+def read_fasta(file_path: str | Path) -> Dict[str, str]:
     """
     Reads a FASTA file and returns a dictionary mapping sequence names to
     their identifiers.
@@ -220,33 +224,29 @@ def download_pdb(
         )
 
     # Make output directory if it doesn't exist or set it to tempdir if None
-    if out_dir is not None:
-        out_dir = Path(out_dir)
-    else:
-        out_dir = Path(tempfile.TemporaryDirectory().name)
-
-    os.makedirs(Path(out_dir), exist_ok=True)
+    out_dir: Path = (
+        Path(out_dir)
+        if out_dir is not None
+        else Path(tempfile.TemporaryDirectory().name)
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     if check_obsolete:
         obs_map = get_obsolete_mapping()
         try:
             new_pdb = obs_map[pdb_code.lower()].lower()
-            log.info(
-                f"{pdb_code} is deprecated. Downloading {new_pdb} instead."
-            )
-            return download_pdb(
-                new_pdb, out_dir, format=format, overwrite=overwrite
-            )
+            log.info(f"{pdb_code} is deprecated. Downloading {new_pdb} instead.")
+            return download_pdb(new_pdb, out_dir, format=format, overwrite=overwrite)
         except KeyError:
-            log.warning(f"PDB {pdb_code} not found. Possibly too large; large \
-                    structures are only provided as mmCIF files.")
+            log.warning(
+                f"PDB {pdb_code} not found. Possibly too large; large \
+                    structures are only provided as mmCIF files."
+            )
             return
 
     # Check if PDB already exists
     if os.path.exists(out_dir / f"{pdb_code}{extension}") and not overwrite:
-        log.debug(
-            f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}"
-        )
+        log.debug(f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}")
         return out_dir / f"{pdb_code}{extension}"
 
     # Download
@@ -359,37 +359,31 @@ def download_alphafold_structure(
     :return: path to output. Tuple if several outputs specified.
     :rtype: Union[str, Tuple[str, str]]
     """
-    BASE_URL = "https://alphafold.ebi.ac.uk/files/"
+
     uniprot_id = uniprot_id.upper()
 
     if not mmcif and not pdb:
         raise ValueError("Must specify either mmcif or pdb.")
     if mmcif:
-        query_url = f"{BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
+        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
     if pdb:
-        query_url = f"{BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
+        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
 
     try:
         structure_filename = wget.download(query_url, out=out_dir)
     except HTTPError:
-        log.warning(
-            f"No structure found for {uniprot_id}. Used URL: {query_url}"
-        )
+        log.warning(f"No structure found for {uniprot_id}. Used URL: {query_url}")
         return None
 
     if rename:
         extension = ".pdb" if pdb else ".cif"
-        os.rename(
-            structure_filename, Path(out_dir) / f"{uniprot_id}{extension}"
-        )
-        structure_filename = str(
-            (Path(out_dir) / f"{uniprot_id}{extension}").resolve()
-        )
+        os.rename(structure_filename, Path(out_dir) / f"{uniprot_id}{extension}")
+        structure_filename = str((Path(out_dir) / f"{uniprot_id}{extension}").resolve())
 
     log.debug(f"Downloaded AlphaFold PDB file for: {uniprot_id}")
     if aligned_score:
         score_query = (
-            BASE_URL
+            ALPHAFOLD_DB_BASE_URL
             + "AF-"
             + uniprot_id
             + f"-F1-predicted_aligned_error_v{version}.json"
@@ -397,9 +391,7 @@ def download_alphafold_structure(
         score_filename = wget.download(score_query, out=out_dir)
         if rename:
             os.rename(score_filename, Path(out_dir) / f"{uniprot_id}.json")
-            score_filename = str(
-                (Path(out_dir) / f"{uniprot_id}.json").resolve()
-            )
+            score_filename = str((Path(out_dir) / f"{uniprot_id}.json").resolve())
         return structure_filename, score_filename
 
     return structure_filename
@@ -578,7 +570,7 @@ def esmfold(
     --------
     self
     """
-    URL = f"https://api.esmatlas.com/foldSequence/v{version}/{format}/"
+    URL = f"{ESM_ATLAS_BASE_URL}{version}/{format}/"
 
     headers: Dict[str, str] = {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -586,18 +578,14 @@ def esmfold(
 
     cif = requests.post(URL, data=sequence, headers=headers).text
     # append header
-    header = "\n".join(
-        [f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"]
-    )
+    header = "\n".join([f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"])
     cif = header + cif
     if out_path is not None:
         with open(out_path, "w") as f:
             f.write(cif)
 
 
-def cast_pdb_column_to_type(
-    pdb: PandasPdb, column_name: str, type: Type
-) -> PandasPdb:
+def cast_pdb_column_to_type(pdb: PandasPdb, column_name: str, type: Type) -> PandasPdb:
     """Casts a specified column within a PandasPdb object to a given type
     and returns the typecasted PandasPdb object.
 
@@ -654,7 +642,5 @@ def extract_chains_to_file(
         df = ppdb.df["ATOM"].loc[ppdb.df["ATOM"]["chain_id"] == chain]
         out_df = PandasPdb()
         out_df.df["ATOM"] = df
-        out_df.to_pdb(
-            path=out_path, records=None, gz=False, append_newline=True
-        )
+        out_df.to_pdb(path=out_path, records=None, gz=False, append_newline=True)
     return out_files

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -235,18 +235,22 @@ def download_pdb(
         obs_map = get_obsolete_mapping()
         try:
             new_pdb = obs_map[pdb_code.lower()].lower()
-            log.info(f"{pdb_code} is deprecated. Downloading {new_pdb} instead.")
-            return download_pdb(new_pdb, out_dir, format=format, overwrite=overwrite)
-        except KeyError:
-            log.warning(
-                f"PDB {pdb_code} not found. Possibly too large; large \
-                    structures are only provided as mmCIF files."
+            log.info(
+                f"{pdb_code} is deprecated. Downloading {new_pdb} instead."
             )
+            return download_pdb(
+                new_pdb, out_dir, format=format, overwrite=overwrite
+            )
+        except KeyError:
+            log.warning(f"PDB {pdb_code} not found. Possibly too large; large \
+                    structures are only provided as mmCIF files.")
             return
 
     # Check if PDB already exists
     if os.path.exists(out_dir / f"{pdb_code}{extension}") and not overwrite:
-        log.debug(f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}")
+        log.debug(
+            f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}"
+        )
         return out_dir / f"{pdb_code}{extension}"
 
     # Download
@@ -365,20 +369,30 @@ def download_alphafold_structure(
     if not mmcif and not pdb:
         raise ValueError("Must specify either mmcif or pdb.")
     if mmcif:
-        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
+        query_url = (
+            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
+        )
     if pdb:
-        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
+        query_url = (
+            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
+        )
 
     try:
         structure_filename = wget.download(query_url, out=out_dir)
     except HTTPError:
-        log.warning(f"No structure found for {uniprot_id}. Used URL: {query_url}")
+        log.warning(
+            f"No structure found for {uniprot_id}. Used URL: {query_url}"
+        )
         return None
 
     if rename:
         extension = ".pdb" if pdb else ".cif"
-        os.rename(structure_filename, Path(out_dir) / f"{uniprot_id}{extension}")
-        structure_filename = str((Path(out_dir) / f"{uniprot_id}{extension}").resolve())
+        os.rename(
+            structure_filename, Path(out_dir) / f"{uniprot_id}{extension}"
+        )
+        structure_filename = str(
+            (Path(out_dir) / f"{uniprot_id}{extension}").resolve()
+        )
 
     log.debug(f"Downloaded AlphaFold PDB file for: {uniprot_id}")
     if aligned_score:
@@ -391,7 +405,9 @@ def download_alphafold_structure(
         score_filename = wget.download(score_query, out=out_dir)
         if rename:
             os.rename(score_filename, Path(out_dir) / f"{uniprot_id}.json")
-            score_filename = str((Path(out_dir) / f"{uniprot_id}.json").resolve())
+            score_filename = str(
+                (Path(out_dir) / f"{uniprot_id}.json").resolve()
+            )
         return structure_filename, score_filename
 
     return structure_filename
@@ -578,14 +594,18 @@ def esmfold(
 
     cif = requests.post(URL, data=sequence, headers=headers).text
     # append header
-    header = "\n".join([f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"])
+    header = "\n".join(
+        [f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"]
+    )
     cif = header + cif
     if out_path is not None:
         with open(out_path, "w") as f:
             f.write(cif)
 
 
-def cast_pdb_column_to_type(pdb: PandasPdb, column_name: str, type: Type) -> PandasPdb:
+def cast_pdb_column_to_type(
+    pdb: PandasPdb, column_name: str, type: Type
+) -> PandasPdb:
     """Casts a specified column within a PandasPdb object to a given type
     and returns the typecasted PandasPdb object.
 
@@ -642,5 +662,7 @@ def extract_chains_to_file(
         df = ppdb.df["ATOM"].loc[ppdb.df["ATOM"]["chain_id"] == chain]
         out_df = PandasPdb()
         out_df.df["ATOM"] = df
-        out_df.to_pdb(path=out_path, records=None, gz=False, append_newline=True)
+        out_df.to_pdb(
+            path=out_path, records=None, gz=False, append_newline=True
+        )
     return out_files

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -224,15 +224,21 @@ def download_pdb(
         )
 
     # Make output directory if it doesn't exist or set it to tempdir if None
-    out_dir: Path = Path(out_dir) if out_dir is not None else Path(tempfile.mkdtemp())
+    out_dir: Path = (
+        Path(out_dir) if out_dir is not None else Path(tempfile.mkdtemp())
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if check_obsolete:
         obs_map = get_obsolete_mapping()
         try:
             new_pdb = obs_map[pdb_code.lower()].lower()
-            log.info(f"{pdb_code} is deprecated. Downloading {new_pdb} instead.")
-            return download_pdb(new_pdb, out_dir, format=format, overwrite=overwrite)
+            log.info(
+                f"{pdb_code} is deprecated. Downloading {new_pdb} instead."
+            )
+            return download_pdb(
+                new_pdb, out_dir, format=format, overwrite=overwrite
+            )
         except KeyError:
             log.warning(f"PDB {pdb_code} not found. Possibly too large; large \
                     structures are only provided as mmCIF files.")
@@ -240,7 +246,9 @@ def download_pdb(
 
     # Check if PDB already exists
     if os.path.exists(out_dir / f"{pdb_code}{extension}") and not overwrite:
-        log.debug(f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}")
+        log.debug(
+            f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}"
+        )
         return out_dir / f"{pdb_code}{extension}"
 
     # Download
@@ -359,20 +367,30 @@ def download_alphafold_structure(
     if not mmcif and not pdb:
         raise ValueError("Must specify either mmcif or pdb.")
     if mmcif:
-        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
+        query_url = (
+            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
+        )
     if pdb:
-        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
+        query_url = (
+            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
+        )
 
     try:
         structure_filename = wget.download(query_url, out=out_dir)
     except HTTPError:
-        log.warning(f"No structure found for {uniprot_id}. Used URL: {query_url}")
+        log.warning(
+            f"No structure found for {uniprot_id}. Used URL: {query_url}"
+        )
         return None
 
     if rename:
         extension = ".pdb" if pdb else ".cif"
-        os.rename(structure_filename, Path(out_dir) / f"{uniprot_id}{extension}")
-        structure_filename = str((Path(out_dir) / f"{uniprot_id}{extension}").resolve())
+        os.rename(
+            structure_filename, Path(out_dir) / f"{uniprot_id}{extension}"
+        )
+        structure_filename = str(
+            (Path(out_dir) / f"{uniprot_id}{extension}").resolve()
+        )
 
     log.debug(f"Downloaded AlphaFold PDB file for: {uniprot_id}")
     if aligned_score:
@@ -385,7 +403,9 @@ def download_alphafold_structure(
         score_filename = wget.download(score_query, out=out_dir)
         if rename:
             os.rename(score_filename, Path(out_dir) / f"{uniprot_id}.json")
-            score_filename = str((Path(out_dir) / f"{uniprot_id}.json").resolve())
+            score_filename = str(
+                (Path(out_dir) / f"{uniprot_id}.json").resolve()
+            )
         return structure_filename, score_filename
 
     return structure_filename
@@ -572,14 +592,18 @@ def esmfold(
 
     cif = requests.post(URL, data=sequence, headers=headers).text
     # append header
-    header = "\n".join([f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"])
+    header = "\n".join(
+        [f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"]
+    )
     cif = header + cif
     if out_path is not None:
         with open(out_path, "w") as f:
             f.write(cif)
 
 
-def cast_pdb_column_to_type(pdb: PandasPdb, column_name: str, type: Type) -> PandasPdb:
+def cast_pdb_column_to_type(
+    pdb: PandasPdb, column_name: str, type: Type
+) -> PandasPdb:
     """Casts a specified column within a PandasPdb object to a given type
     and returns the typecasted PandasPdb object.
 
@@ -636,5 +660,7 @@ def extract_chains_to_file(
         df = ppdb.df["ATOM"].loc[ppdb.df["ATOM"]["chain_id"] == chain]
         out_df = PandasPdb()
         out_df.df["ATOM"] = df
-        out_df.to_pdb(path=out_path, records=None, gz=False, append_newline=True)
+        out_df.to_pdb(
+            path=out_path, records=None, gz=False, append_newline=True
+        )
     return out_files

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -22,7 +22,7 @@ import requests
 import wget
 from biopandas.pdb import PandasPdb
 from loguru import logger as log
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .resi_atoms import BACKBONE_ATOMS, RESI_THREE_TO_1
 
@@ -224,21 +224,15 @@ def download_pdb(
         )
 
     # Make output directory if it doesn't exist or set it to tempdir if None
-    out_dir: Path = (
-        Path(out_dir) if out_dir is not None else Path(tempfile.mkdtemp())
-    )
+    out_dir: Path = Path(out_dir) if out_dir is not None else Path(tempfile.mkdtemp())
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if check_obsolete:
         obs_map = get_obsolete_mapping()
         try:
             new_pdb = obs_map[pdb_code.lower()].lower()
-            log.info(
-                f"{pdb_code} is deprecated. Downloading {new_pdb} instead."
-            )
-            return download_pdb(
-                new_pdb, out_dir, format=format, overwrite=overwrite
-            )
+            log.info(f"{pdb_code} is deprecated. Downloading {new_pdb} instead.")
+            return download_pdb(new_pdb, out_dir, format=format, overwrite=overwrite)
         except KeyError:
             log.warning(f"PDB {pdb_code} not found. Possibly too large; large \
                     structures are only provided as mmCIF files.")
@@ -246,9 +240,7 @@ def download_pdb(
 
     # Check if PDB already exists
     if os.path.exists(out_dir / f"{pdb_code}{extension}") and not overwrite:
-        log.debug(
-            f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}"
-        )
+        log.debug(f"{pdb_code} already exists: {out_dir / f'{pdb_code}{extension}'}")
         return out_dir / f"{pdb_code}{extension}"
 
     # Download
@@ -367,30 +359,20 @@ def download_alphafold_structure(
     if not mmcif and not pdb:
         raise ValueError("Must specify either mmcif or pdb.")
     if mmcif:
-        query_url = (
-            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
-        )
+        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.cif"
     if pdb:
-        query_url = (
-            f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
-        )
+        query_url = f"{ALPHAFOLD_DB_BASE_URL}AF-{uniprot_id}-F1-model_v{version}.pdb"
 
     try:
         structure_filename = wget.download(query_url, out=out_dir)
     except HTTPError:
-        log.warning(
-            f"No structure found for {uniprot_id}. Used URL: {query_url}"
-        )
+        log.warning(f"No structure found for {uniprot_id}. Used URL: {query_url}")
         return None
 
     if rename:
         extension = ".pdb" if pdb else ".cif"
-        os.rename(
-            structure_filename, Path(out_dir) / f"{uniprot_id}{extension}"
-        )
-        structure_filename = str(
-            (Path(out_dir) / f"{uniprot_id}{extension}").resolve()
-        )
+        os.rename(structure_filename, Path(out_dir) / f"{uniprot_id}{extension}")
+        structure_filename = str((Path(out_dir) / f"{uniprot_id}{extension}").resolve())
 
     log.debug(f"Downloaded AlphaFold PDB file for: {uniprot_id}")
     if aligned_score:
@@ -403,9 +385,7 @@ def download_alphafold_structure(
         score_filename = wget.download(score_query, out=out_dir)
         if rename:
             os.rename(score_filename, Path(out_dir) / f"{uniprot_id}.json")
-            score_filename = str(
-                (Path(out_dir) / f"{uniprot_id}.json").resolve()
-            )
+            score_filename = str((Path(out_dir) / f"{uniprot_id}.json").resolve())
         return structure_filename, score_filename
 
     return structure_filename
@@ -592,18 +572,14 @@ def esmfold(
 
     cif = requests.post(URL, data=sequence, headers=headers).text
     # append header
-    header = "\n".join(
-        [f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"]
-    )
+    header = "\n".join([f"data_{sequence}", "#", f"_entry.id\t{sequence}", "#\n"])
     cif = header + cif
     if out_path is not None:
         with open(out_path, "w") as f:
             f.write(cif)
 
 
-def cast_pdb_column_to_type(
-    pdb: PandasPdb, column_name: str, type: Type
-) -> PandasPdb:
+def cast_pdb_column_to_type(pdb: PandasPdb, column_name: str, type: Type) -> PandasPdb:
     """Casts a specified column within a PandasPdb object to a given type
     and returns the typecasted PandasPdb object.
 
@@ -660,7 +636,5 @@ def extract_chains_to_file(
         df = ppdb.df["ATOM"].loc[ppdb.df["ATOM"]["chain_id"] == chain]
         out_df = PandasPdb()
         out_df.df["ATOM"] = df
-        out_df.to_pdb(
-            path=out_path, records=None, gz=False, append_newline=True
-        )
+        out_df.to_pdb(path=out_path, records=None, gz=False, append_newline=True)
     return out_files

--- a/graphein/protein/utils.py
+++ b/graphein/protein/utils.py
@@ -225,9 +225,7 @@ def download_pdb(
 
     # Make output directory if it doesn't exist or set it to tempdir if None
     out_dir: Path = (
-        Path(out_dir)
-        if out_dir is not None
-        else Path(tempfile.TemporaryDirectory().name)
+        Path(out_dir) if out_dir is not None else Path(tempfile.mkdtemp())
     )
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,9 @@ class UploadCommand(Command):
             self.status("Removing previous builds…")
             rmtree(os.path.join(HERE, "dist"))
         self.status("Building Source and Wheel (universal) distribution…")
-        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
+        os.system(
+            "{0} setup.py sdist bdist_wheel --universal".format(sys.executable)
+        )
 
         self.status("Uploading the package to PyPI via Twine…")
         os.system("twine upload dist/*")
@@ -146,7 +148,9 @@ setup(
         "documentation": "https://graphein.ai/",
     },
     packages=find_packages(),
-    package_data={"": ["LICENSE.txt", "README.md", "requirements.txt", "*.csv"]},
+    package_data={
+        "": ["LICENSE.txt", "README.md", "requirements.txt", "*.csv"]
+    },
     include_package_data=True,
     # install_requires=install_reqs,
     install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,7 @@ class UploadCommand(Command):
             self.status("Removing previous builds…")
             rmtree(os.path.join(HERE, "dist"))
         self.status("Building Source and Wheel (universal) distribution…")
-        os.system(
-            "{0} setup.py sdist bdist_wheel --universal".format(sys.executable)
-        )
+        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
 
         self.status("Uploading the package to PyPI via Twine…")
         os.system("twine upload dist/*")
@@ -148,14 +146,12 @@ setup(
         "documentation": "https://graphein.ai/",
     },
     packages=find_packages(),
-    package_data={
-        "": ["LICENSE.txt", "README.md", "requirements.txt", "*.csv"]
-    },
+    package_data={"": ["LICENSE.txt", "README.md", "requirements.txt", "*.csv"]},
     include_package_data=True,
     # install_requires=install_reqs,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     license="MIT",
     platforms="any",
     classifiers=[
@@ -165,11 +161,9 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: Unix",
         "Operating System :: MacOS",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
     ],
     # $ setup.py publish support.

--- a/tests/ml/test_dataset_utils.py
+++ b/tests/ml/test_dataset_utils.py
@@ -5,6 +5,8 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 MODULE_PATH = (
     Path(__file__).resolve().parents[2] / "graphein/ml/datasets/utils.py"
 )
@@ -161,3 +163,22 @@ def test_generate_pdb_ligand_mappings_uses_requested_types(
     assert config.DATA_API_MAX_CONCURRENT_REQUESTS == 7
     assert pdb_to_cc_output_file.read_text() == "1ABC\tATP\n"
     assert cc_to_pdb_output_file.read_text() == "ATP\t1ABC\n"
+
+
+def test_generate_pdb_ligand_mappings_rejects_invalid_types(
+    monkeypatch, tmp_path
+):
+    module, config = _load_dataset_utils_module(monkeypatch)
+
+    with pytest.raises(ValueError) as excinfo:
+        module.generate_pdb_ligand_mappings(
+            chem_comp_types=("nonpolymer", "invalid_type"),
+            pdb_to_cc_output_file=tmp_path / "pdb-to-cc.tsv",
+            cc_to_pdb_output_file=tmp_path / "cc-to-pdb.tsv",
+        )
+
+    assert str(excinfo.value) == (
+        "Invalid chem_comp_types: ['invalid_type']. Allowed values are: "
+        f"{module.ALLOWED_CHEM_COMP_TYPES}."
+    )
+    assert config.DATA_API_MAX_CONCURRENT_REQUESTS is None

--- a/tests/ml/test_dataset_utils.py
+++ b/tests/ml/test_dataset_utils.py
@@ -5,7 +5,6 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
-
 MODULE_PATH = (
     Path(__file__).resolve().parents[2] / "graphein/ml/datasets/utils.py"
 )
@@ -46,7 +45,9 @@ def _load_dataset_utils_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "rcsbapi.config", config_module)
     monkeypatch.setitem(sys.modules, "rcsbapi.data", data_module)
 
-    spec = spec_from_file_location("test_graphein_ml_datasets_utils", MODULE_PATH)
+    spec = spec_from_file_location(
+        "test_graphein_ml_datasets_utils", MODULE_PATH
+    )
     module = module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)

--- a/tests/ml/test_dataset_utils.py
+++ b/tests/ml/test_dataset_utils.py
@@ -1,0 +1,162 @@
+"""Tests for ligand dataset utility helpers."""
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "graphein/ml/datasets/utils.py"
+)
+
+
+class _DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+
+def _load_dataset_utils_module(monkeypatch):
+    config = SimpleNamespace(DATA_API_MAX_CONCURRENT_REQUESTS=None)
+
+    loguru_module = ModuleType("loguru")
+    loguru_module.logger = _DummyLogger()
+
+    rcsbapi_module = ModuleType("rcsbapi")
+    config_module = ModuleType("rcsbapi.config")
+    config_module.config = config
+
+    data_module = ModuleType("rcsbapi.data")
+    data_module.ALL_STRUCTURES = "ALL_STRUCTURES"
+
+    class DummyQuery:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def exec(self, progress_bar=True):
+            return {"data": {"entries": []}}
+
+    data_module.DataQuery = DummyQuery
+    rcsbapi_module.config = config_module
+    rcsbapi_module.data = data_module
+
+    monkeypatch.setitem(sys.modules, "loguru", loguru_module)
+    monkeypatch.setitem(sys.modules, "rcsbapi", rcsbapi_module)
+    monkeypatch.setitem(sys.modules, "rcsbapi.config", config_module)
+    monkeypatch.setitem(sys.modules, "rcsbapi.data", data_module)
+
+    spec = spec_from_file_location("test_graphein_ml_datasets_utils", MODULE_PATH)
+    module = module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, config
+
+
+def test_process_chem_comp_results_writes_sorted_mapping_files(
+    monkeypatch, tmp_path
+):
+    module, _ = _load_dataset_utils_module(monkeypatch)
+    pdb_to_cc_output_file = tmp_path / "pdb-to-cc.tsv"
+    cc_to_pdb_output_file = tmp_path / "cc-to-pdb.tsv"
+
+    entry_chem_comp_results = [
+        {
+            "rcsb_id": "2DEF",
+            "nonpolymer_entities": [
+                {
+                    "rcsb_nonpolymer_entity_container_identifiers": {
+                        "nonpolymer_comp_id": "ATP"
+                    }
+                }
+            ],
+            "branched_entities": [
+                {
+                    "rcsb_branched_entity_container_identifiers": {
+                        "chem_comp_monomers": ["NAG", "ATP"]
+                    }
+                }
+            ],
+            "polymer_entities": [
+                {
+                    "rcsb_polymer_entity_container_identifiers": {
+                        "chem_comp_nstd_monomers": ["MSE"]
+                    }
+                }
+            ],
+        },
+        {
+            "rcsb_id": "1ABC",
+            "nonpolymer_entities": [
+                {
+                    "rcsb_nonpolymer_entity_container_identifiers": {
+                        "nonpolymer_comp_id": "HEM"
+                    }
+                },
+                {
+                    "rcsb_nonpolymer_entity_container_identifiers": {
+                        "nonpolymer_comp_id": "ATP"
+                    }
+                },
+            ],
+        },
+    ]
+
+    module.process_chem_comp_results_and_write_to_file(
+        entry_chem_comp_results=entry_chem_comp_results,
+        pdb_to_cc_output_file=pdb_to_cc_output_file,
+        cc_to_pdb_output_file=cc_to_pdb_output_file,
+        cc_extras_output_file=tmp_path / "cc-counts-extra.tsv",
+        generate_cc_extra_file=False,
+    )
+
+    assert pdb_to_cc_output_file.read_text() == (
+        "2DEF\tATP MSE NAG\n1ABC\tATP HEM\n"
+    )
+    assert cc_to_pdb_output_file.read_text() == (
+        "ATP\t1ABC 2DEF\nNAG\t2DEF\nMSE\t2DEF\nHEM\t1ABC\n"
+    )
+
+
+def test_generate_pdb_ligand_mappings_uses_requested_types(
+    monkeypatch, tmp_path
+):
+    module, config = _load_dataset_utils_module(monkeypatch)
+    observed = {}
+
+    def fake_fetch_all_chem_comp_ids(chem_comp_types_to_include):
+        observed["chem_comp_types_to_include"] = chem_comp_types_to_include
+        return [
+            {
+                "rcsb_id": "1ABC",
+                "nonpolymer_entities": [
+                    {
+                        "rcsb_nonpolymer_entity_container_identifiers": {
+                            "nonpolymer_comp_id": "ATP"
+                        }
+                    }
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(
+        module, "fetch_all_chem_comp_ids", fake_fetch_all_chem_comp_ids
+    )
+
+    pdb_to_cc_output_file = tmp_path / "pdb-to-cc.tsv"
+    cc_to_pdb_output_file = tmp_path / "cc-to-pdb.tsv"
+    module.generate_pdb_ligand_mappings(
+        chem_comp_types=("nonpolymer", "polymer_std"),
+        pdb_to_cc_output_file=pdb_to_cc_output_file,
+        cc_to_pdb_output_file=cc_to_pdb_output_file,
+        max_concurrent_api_requests=7,
+        generate_cc_extra_file=False,
+    )
+
+    assert observed["chem_comp_types_to_include"] == [
+        module.CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS["nonpolymer"],
+        module.CHEMICAL_COMPONENT_TYPES_ARG_MAPPINGS["polymer_std"],
+    ]
+    assert config.DATA_API_MAX_CONCURRENT_REQUESTS == 7
+    assert pdb_to_cc_output_file.read_text() == "1ABC\tATP\n"
+    assert cc_to_pdb_output_file.read_text() == "ATP\t1ABC\n"

--- a/tests/ml/test_pdb_data.py
+++ b/tests/ml/test_pdb_data.py
@@ -1,0 +1,131 @@
+"""Tests for ligand map generation in the ML PDB dataset manager."""
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "graphein/ml/datasets/pdb_data.py"
+)
+
+
+class _DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+
+def _load_pdb_data_module(monkeypatch):
+    numpy_module = ModuleType("numpy")
+    numpy_module.datetime64 = object
+
+    pandas_module = ModuleType("pandas")
+    pandas_module.DataFrame = object
+    pandas_module.Series = object
+    pandas_core_module = ModuleType("pandas.core")
+    pandas_groupby_module = ModuleType("pandas.core.groupby")
+    pandas_generic_module = ModuleType("pandas.core.groupby.generic")
+    pandas_generic_module.DataFrameGroupBy = object
+
+    wget_module = ModuleType("wget")
+    wget_module.download = lambda *args, **kwargs: None
+
+    biopandas_module = ModuleType("biopandas")
+    biopandas_pdb_module = ModuleType("biopandas.pdb")
+    biopandas_pdb_module.PandasPdb = object
+
+    loguru_module = ModuleType("loguru")
+    loguru_module.logger = _DummyLogger()
+
+    tqdm_module = ModuleType("tqdm")
+    tqdm_auto_module = ModuleType("tqdm.auto")
+    tqdm_auto_module.tqdm = lambda iterable=None, *args, **kwargs: iterable
+
+    graphein_module = ModuleType("graphein")
+    graphein_ml_module = ModuleType("graphein.ml")
+    graphein_ml_datasets_module = ModuleType("graphein.ml.datasets")
+    graphein_utils_module = ModuleType("graphein.utils")
+    graphein_protein_module = ModuleType("graphein.protein")
+
+    dataset_utils_module = ModuleType("graphein.ml.datasets.utils")
+    dataset_utils_module.generate_pdb_ligand_mappings = (
+        lambda *args, **kwargs: None
+    )
+
+    protein_utils_module = ModuleType("graphein.protein.utils")
+    protein_utils_module.cast_pdb_column_to_type = lambda *args, **kwargs: None
+    protein_utils_module.download_pdb_multiprocessing = (
+        lambda *args, **kwargs: None
+    )
+    protein_utils_module.extract_chains_to_file = (
+        lambda *args, **kwargs: None
+    )
+    protein_utils_module.read_fasta = lambda *args, **kwargs: None
+
+    dependencies_module = ModuleType("graphein.utils.dependencies")
+    dependencies_module.is_tool = lambda *args, **kwargs: True
+
+    monkeypatch.setitem(sys.modules, "numpy", numpy_module)
+    monkeypatch.setitem(sys.modules, "pandas", pandas_module)
+    monkeypatch.setitem(sys.modules, "pandas.core", pandas_core_module)
+    monkeypatch.setitem(
+        sys.modules, "pandas.core.groupby", pandas_groupby_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "pandas.core.groupby.generic", pandas_generic_module
+    )
+    monkeypatch.setitem(sys.modules, "wget", wget_module)
+    monkeypatch.setitem(sys.modules, "biopandas", biopandas_module)
+    monkeypatch.setitem(sys.modules, "biopandas.pdb", biopandas_pdb_module)
+    monkeypatch.setitem(sys.modules, "loguru", loguru_module)
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_module)
+    monkeypatch.setitem(sys.modules, "tqdm.auto", tqdm_auto_module)
+    monkeypatch.setitem(sys.modules, "graphein", graphein_module)
+    monkeypatch.setitem(sys.modules, "graphein.ml", graphein_ml_module)
+    monkeypatch.setitem(
+        sys.modules, "graphein.ml.datasets", graphein_ml_datasets_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "graphein.ml.datasets.utils", dataset_utils_module
+    )
+    monkeypatch.setitem(sys.modules, "graphein.protein", graphein_protein_module)
+    monkeypatch.setitem(
+        sys.modules, "graphein.protein.utils", protein_utils_module
+    )
+    monkeypatch.setitem(sys.modules, "graphein.utils", graphein_utils_module)
+    monkeypatch.setitem(
+        sys.modules, "graphein.utils.dependencies", dependencies_module
+    )
+
+    spec = spec_from_file_location(
+        "test_graphein_ml_datasets_pdb_data", MODULE_PATH
+    )
+    module = module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_ligand_map_uses_distinct_intermediate_output(
+    monkeypatch, tmp_path
+):
+    module = _load_pdb_data_module(monkeypatch)
+    observed = {}
+
+    def fake_generate_pdb_ligand_mappings(**kwargs):
+        observed.update(kwargs)
+
+    monkeypatch.setattr(
+        module, "generate_pdb_ligand_mappings", fake_generate_pdb_ligand_mappings
+    )
+
+    manager = module.PDBManager.__new__(module.PDBManager)
+    manager.root_dir = tmp_path
+    manager.ligand_map_filename = "cc-to-pdb.tdd"
+
+    manager._generate_ligand_map()
+
+    assert observed["cc_to_pdb_output_file"] == tmp_path / "cc-to-pdb.tdd"
+    assert observed["generate_cc_extra_file"] is False
+    assert observed["pdb_to_cc_output_file"] != observed["cc_to_pdb_output_file"]
+    assert Path(observed["pdb_to_cc_output_file"]).name == "pdb-to-cc.tsv"

--- a/tests/ml/test_torch_geometric_dataset.py
+++ b/tests/ml/test_torch_geometric_dataset.py
@@ -45,7 +45,9 @@ def test_list_dataset():
     graphs = [convertor(g) for g in graphs]
 
     # Create dataset
-    ds = ProteinGraphListDataset(root=ROOT_DIR, data_list=graphs, name="list_test")
+    ds = ProteinGraphListDataset(
+        root=ROOT_DIR, data_list=graphs, name="list_test"
+    )
 
     assert len(ds) == len(graphs)
     assert os.path.exists(ROOT_DIR / "processed" / "data_list_test.pt")

--- a/tests/ml/test_torch_geometric_dataset.py
+++ b/tests/ml/test_torch_geometric_dataset.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from loguru import logger
 from numpy.testing import assert_array_equal
 
 import graphein.protein as gp
@@ -23,8 +24,8 @@ try:
         ProteinGraphDataset,
         ProteinGraphListDataset,
     )
-except (NameError, ImportError):
-    pass
+except (NameError, ImportError) as e:
+    logger.error("e")
 
 ROOT_DIR = Path(__file__).parent
 
@@ -44,9 +45,7 @@ def test_list_dataset():
     graphs = [convertor(g) for g in graphs]
 
     # Create dataset
-    ds = ProteinGraphListDataset(
-        root=ROOT_DIR, data_list=graphs, name="list_test"
-    )
+    ds = ProteinGraphListDataset(root=ROOT_DIR, data_list=graphs, name="list_test")
 
     assert len(ds) == len(graphs)
     assert os.path.exists(ROOT_DIR / "processed" / "data_list_test.pt")

--- a/tests/ml/test_torch_geometric_dataset.py
+++ b/tests/ml/test_torch_geometric_dataset.py
@@ -24,8 +24,19 @@ try:
         ProteinGraphDataset,
         ProteinGraphListDataset,
     )
+
+    PYG_DATASETS_AVAIL = all(
+        x is not None
+        for x in (
+            InMemoryProteinGraphDataset,
+            ProteinGraphDataset,
+            ProteinGraphListDataset,
+        )
+    )
 except (NameError, ImportError) as e:
-    logger.error("e")
+    logger.error(e)
+    PYG_DATASETS_AVAIL = False
+
 
 ROOT_DIR = Path(__file__).parent
 

--- a/tests/molecule/test_rdkit_utils.py
+++ b/tests/molecule/test_rdkit_utils.py
@@ -23,26 +23,20 @@ def test_get_center():
         center, np.ndarray
     ), f"Center is not a numpy array ({type(center)}"
     assert center.shape == (3,), f"Center has wrong shape ({center.shape})"
-    np.testing.assert_allclose(
-        np.array([-0.21303333, 0.06743333, 0.0818]), center
-    )
+    np.testing.assert_allclose(np.array([-0.21303333, 0.06743333, 0.0818]), center)
 
 
 def test_get_shape_moments():
     moments = u.get_shape_moments(TEST_MOL_GRAPH)
-    assert isinstance(
-        moments, tuple
-    ), f"Moment is not a tuple ({type(moments)})"
-    assert isinstance(
-        moments[0], float
-    ), f"Moment is not a float ({type(moments[0])})"
-    assert isinstance(
-        moments[1], float
-    ), f"Moment is not a float ({type(moments[1])})"
-    assert moments == (
-        0.12940962096031391,
-        0.8705903790396854,
-    ), f"Moments are not correct ({moments})"
+    assert isinstance(moments, tuple), f"Moment is not a tuple ({type(moments)})"
+    assert isinstance(moments[0], float), f"Moment is not a float ({type(moments[0])})"
+    assert isinstance(moments[1], float), f"Moment is not a float ({type(moments[1])})"
+    assert np.isclose(
+        moments[0], 0.12940962096031391
+    ), f"Moment 0 is not correct ({moments[0]})"
+    assert np.isclose(
+        moments[1], 0.8705903790396854
+    ), f"Moment 1 is not correct ({moments[1]})"
 
 
 def test_count_fragment():

--- a/tests/molecule/test_rdkit_utils.py
+++ b/tests/molecule/test_rdkit_utils.py
@@ -23,14 +23,22 @@ def test_get_center():
         center, np.ndarray
     ), f"Center is not a numpy array ({type(center)}"
     assert center.shape == (3,), f"Center has wrong shape ({center.shape})"
-    np.testing.assert_allclose(np.array([-0.21303333, 0.06743333, 0.0818]), center)
+    np.testing.assert_allclose(
+        np.array([-0.21303333, 0.06743333, 0.0818]), center
+    )
 
 
 def test_get_shape_moments():
     moments = u.get_shape_moments(TEST_MOL_GRAPH)
-    assert isinstance(moments, tuple), f"Moment is not a tuple ({type(moments)})"
-    assert isinstance(moments[0], float), f"Moment is not a float ({type(moments[0])})"
-    assert isinstance(moments[1], float), f"Moment is not a float ({type(moments[1])})"
+    assert isinstance(
+        moments, tuple
+    ), f"Moment is not a tuple ({type(moments)})"
+    assert isinstance(
+        moments[0], float
+    ), f"Moment is not a float ({type(moments[0])})"
+    assert isinstance(
+        moments[1], float
+    ), f"Moment is not a float ({type(moments[1])})"
     assert np.isclose(
         moments[0], 0.12940962096031391
     ), f"Moment 0 is not correct ({moments[0]})"


### PR DESCRIPTION
#### Reference Issues/PRs
#444 

#### What does this implement/fix? Explain your changes
Removes download of chemical component to PDB ID map from Ligand expo. Instead, creates this map based on querying the RCSB API.

#### What testing did you do to verify the changes in this PR?
Manual inspection. Not thorough, but LGTM.


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
